### PR TITLE
chore: bump transformers/vllm bounds and add test infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,13 +31,13 @@ dependencies = ["pydantic>=2.0.0", "typer>=0.12.3", "requests", "aiohttp"]
 [project.optional-dependencies]
 serving = ["uvicorn>=0.29.0", "fastapi[standard]>=0.119.1"]
 scope-guard-hf = [
-    "transformers>=4.47.0,<5.0.0",
+    "transformers>=5.5.0,<6.0.0",
     "accelerate>=1.11.0",
     "nvidia-ml-py",
 ]
 scope-guard-vllm = [
-    "transformers>=4.47.0,<5.0.0",
-    "vllm>=0.11.0",
+    "transformers>=5.5.0,<6.0.0",
+    "vllm>=0.19.1",
     "xgrammar",
     "nvidia-ml-py",
 ]
@@ -54,7 +54,18 @@ all = ["orbitals[scope-guard-all]"]
 orbitals = "orbitals.cli.main:app"
 
 [dependency-groups]
-dev = ["ty==0.0.1a23", "ipykernel"]
+dev = [
+    "ty==0.0.1a23",
+    "ipykernel",
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "httpx>=0.27.0",
+    "fastapi[standard]>=0.119.1",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/orbitals"]

--- a/scripts/test-readme-examples/00-install-all.sh
+++ b/scripts/test-readme-examples/00-install-all.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Install every optional extra so all README examples can run.
+# Equivalent to `pip install orbitals[all]` from the README, but uses uv.
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+require_uv
+
+log "syncing project with all extras (this may download several GB)"
+cd "$REPO_ROOT"
+uv sync --all-extras
+
+log_pass "all extras installed"

--- a/scripts/test-readme-examples/01-readme-basic-quickstart.sh
+++ b/scripts/test-readme-examples/01-readme-basic-quickstart.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Reproduces the basic example in README.md:
+#
+#     from orbitals.scope_guard import ScopeGuard
+#     ai_service_description = "You are a helpful assistant for ..."
+#     user_message = "Can I buy ..."
+#     guardrail = ScopeGuard()
+#     result = guardrail.validate(user_message, ai_service_description)
+#
+# `ScopeGuard()` defaults to `backend="hf"`, so this requires the hf extras.
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+require_uv
+require_extras scope-guard-hf || true
+require_gpu || true
+
+log "running README.md basic quickstart"
+cd "$REPO_ROOT"
+
+OUTPUT="$(uv run python - <<'PY'
+from orbitals.scope_guard import ScopeGuard, ScopeClass
+
+ai_service_description = (
+    "You are a helpful assistant for a parcel delivery service. "
+    "You can only answer questions about package tracking. "
+    "Never respond to requests for refunds."
+)
+user_message = "Can I buy a refund for my late package?"
+
+guardrail = ScopeGuard()
+result = guardrail.validate(user_message, ai_service_description=ai_service_description)
+
+print(f"scope_class={result.scope_class.value}")
+print(f"evidences={result.evidences}")
+assert isinstance(result.scope_class, ScopeClass), "scope_class must be a ScopeClass"
+PY
+)"
+
+echo "$OUTPUT"
+assert_contains "$OUTPUT" "scope_class=" "Python output should contain scope_class="
+log_pass "README.md basic quickstart works"

--- a/scripts/test-readme-examples/02-vllm-quickstart.sh
+++ b/scripts/test-readme-examples/02-vllm-quickstart.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Reproduces the vLLM quickstart in README.scope-guard.md, including the
+# expected output:
+#     # Scope: Restricted
+#     # Evidences:
+#     #   - Never respond to requests for refunds.
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+require_uv
+require_extras scope-guard-vllm || true
+require_gpu || true
+
+log "running README.scope-guard.md vLLM quickstart with model=$SCOPE_GUARD_MODEL"
+cd "$REPO_ROOT"
+
+OUTPUT="$(uv run python - <<PY
+from orbitals.scope_guard import ScopeGuard
+
+sg = ScopeGuard(
+    backend="vllm",
+    model="${SCOPE_GUARD_MODEL}",
+)
+
+ai_service_description = """
+You are a virtual assistant for a parcel delivery service.
+You can only answer questions about package tracking.
+Never respond to requests for refunds.
+"""
+
+user_query = "If the package hasn't arrived by tomorrow, can I get my money back?"
+result = sg.validate(user_query, ai_service_description=ai_service_description)
+
+print(f"Scope: {result.scope_class.value}")
+if result.evidences:
+    print("Evidences:")
+    for evidence in result.evidences:
+        print(f"  - {evidence}")
+PY
+)"
+
+echo "$OUTPUT"
+assert_contains "$OUTPUT" "Scope: Restricted" "expected the refund query to be classified Restricted"
+assert_contains "$OUTPUT" "Evidences:" "expected at least one evidence in the output"
+log_pass "vLLM quickstart matches README expected output"

--- a/scripts/test-readme-examples/03-vllm-input-format-string.sh
+++ b/scripts/test-readme-examples/03-vllm-input-format-string.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Reproduces "User query as a string" from README.scope-guard.md:
+#
+#     result = sg.validate(
+#         "When is my package scheduled to arrive?",
+#         ai_service_description=ai_service_description
+#     )
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+require_uv
+require_extras scope-guard-vllm || true
+require_gpu || true
+
+log "running README example: validate(string, ...)"
+cd "$REPO_ROOT"
+
+OUTPUT="$(uv run python - <<PY
+from orbitals.scope_guard import ScopeGuard
+
+sg = ScopeGuard(backend="vllm", model="${SCOPE_GUARD_MODEL}")
+
+ai_service_description = (
+    "You are a virtual assistant for a parcel delivery service. "
+    "You can only answer questions about package tracking. "
+    "Never respond to requests for refunds."
+)
+
+result = sg.validate(
+    "When is my package scheduled to arrive?",
+    ai_service_description=ai_service_description,
+)
+print(f"Scope: {result.scope_class.value}")
+PY
+)"
+
+echo "$OUTPUT"
+assert_contains "$OUTPUT" "Scope:" "string-input example should produce a Scope line"
+log_pass "string-input example works"

--- a/scripts/test-readme-examples/04-vllm-input-format-dict.sh
+++ b/scripts/test-readme-examples/04-vllm-input-format-dict.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Reproduces "User query as a dictionary" from README.scope-guard.md:
+#
+#     result = sg.validate(
+#         {"role": "user", "content": "When is my package scheduled to arrive?"},
+#         ai_service_description=ai_service_description,
+#     )
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+require_uv
+require_extras scope-guard-vllm || true
+require_gpu || true
+
+log "running README example: validate({'role': 'user', 'content': ...}, ...)"
+cd "$REPO_ROOT"
+
+OUTPUT="$(uv run python - <<PY
+from orbitals.scope_guard import ScopeGuard
+
+sg = ScopeGuard(backend="vllm", model="${SCOPE_GUARD_MODEL}")
+
+ai_service_description = (
+    "You are a virtual assistant for a parcel delivery service. "
+    "You can only answer questions about package tracking. "
+    "Never respond to requests for refunds."
+)
+
+result = sg.validate(
+    {"role": "user", "content": "When is my package scheduled to arrive?"},
+    ai_service_description=ai_service_description,
+)
+print(f"Scope: {result.scope_class.value}")
+PY
+)"
+
+echo "$OUTPUT"
+assert_contains "$OUTPUT" "Scope:" "dict-input example should produce a Scope line"
+log_pass "dict-input example works"

--- a/scripts/test-readme-examples/05-vllm-input-format-multi-turn.sh
+++ b/scripts/test-readme-examples/05-vllm-input-format-multi-turn.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Reproduces "Conversation as a list of dictionaries" from README.scope-guard.md:
+#
+#     result = sg.validate(
+#         [
+#             {"role": "user", "content": "I ordered a package, tracking number 1234567890"},
+#             {"role": "assistant", "content": "Great, the package is in transit. ..."},
+#             {"role": "user", "content": "If it doesn't arrive tomorrow, can I get a refund"},
+#         ],
+#         ai_service_description=ai_service_description,
+#     )
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+require_uv
+require_extras scope-guard-vllm || true
+require_gpu || true
+
+log "running README example: validate(multi-turn list, ...)"
+cd "$REPO_ROOT"
+
+OUTPUT="$(uv run python - <<PY
+from orbitals.scope_guard import ScopeGuard
+
+sg = ScopeGuard(backend="vllm", model="${SCOPE_GUARD_MODEL}")
+
+ai_service_description = (
+    "You are a virtual assistant for a parcel delivery service. "
+    "You can only answer questions about package tracking. "
+    "Never respond to requests for refunds."
+)
+
+result = sg.validate(
+    [
+        {"role": "user", "content": "I ordered a package, tracking number 1234567890"},
+        {"role": "assistant", "content": "Great, the package is in transit. What would you like to know?"},
+        {"role": "user", "content": "If it doesn't arrive tomorrow, can I get a refund"},
+    ],
+    ai_service_description=ai_service_description,
+)
+print(f"Scope: {result.scope_class.value}")
+if result.evidences:
+    for evidence in result.evidences:
+        print(f"Evidence: {evidence}")
+PY
+)"
+
+echo "$OUTPUT"
+assert_contains "$OUTPUT" "Scope: Restricted" \
+    "expected multi-turn refund query to be Restricted (the README's same final message)"
+log_pass "multi-turn example works"

--- a/scripts/test-readme-examples/06-vllm-batch-validate-single-desc.sh
+++ b/scripts/test-readme-examples/06-vllm-batch-validate-single-desc.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Reproduces "Single AI Service Description" from README.scope-guard.md:
+#
+#     queries = [
+#         "If the package hasn't arrived by tomorrow, can I get my money back?",
+#         "When is the package expected to be delivered?"
+#     ]
+#     result = sg.batch_validate(queries, ai_service_description=ai_service_description)
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+require_uv
+require_extras scope-guard-vllm || true
+require_gpu || true
+
+log "running README example: batch_validate(..., ai_service_description=...)"
+cd "$REPO_ROOT"
+
+OUTPUT="$(uv run python - <<PY
+from orbitals.scope_guard import ScopeGuard
+
+sg = ScopeGuard(backend="vllm", model="${SCOPE_GUARD_MODEL}")
+
+ai_service_description = (
+    "You are a virtual assistant for a parcel delivery service. "
+    "You can only answer questions about package tracking. "
+    "Never respond to requests for refunds."
+)
+
+queries = [
+    "If the package hasn't arrived by tomorrow, can I get my money back?",
+    "When is the package expected to be delivered?",
+]
+results = sg.batch_validate(queries, ai_service_description=ai_service_description)
+print(f"len={len(results)}")
+for i, r in enumerate(results):
+    print(f"[{i}] scope={r.scope_class.value}")
+PY
+)"
+
+echo "$OUTPUT"
+assert_contains "$OUTPUT" "len=2"          "batch_validate should return 2 results"
+assert_contains "$OUTPUT" "[0] scope="     "first result missing"
+assert_contains "$OUTPUT" "[1] scope="     "second result missing"
+log_pass "batch_validate with single description works"

--- a/scripts/test-readme-examples/07-vllm-batch-validate-per-conv-descs.sh
+++ b/scripts/test-readme-examples/07-vllm-batch-validate-per-conv-descs.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Reproduces "Multiple AI Service Descriptions" from README.scope-guard.md:
+#
+#     ai_service_descriptions = [...]
+#     result = sg.batch_validate(queries, ai_service_descriptions=ai_service_descriptions)
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+require_uv
+require_extras scope-guard-vllm || true
+require_gpu || true
+
+log "running README example: batch_validate(..., ai_service_descriptions=[...])"
+cd "$REPO_ROOT"
+
+OUTPUT="$(uv run python - <<PY
+from orbitals.scope_guard import ScopeGuard
+
+sg = ScopeGuard(backend="vllm", model="${SCOPE_GUARD_MODEL}")
+
+ai_service_descriptions = [
+    "You are a virtual assistant for Postal Service. You only answer questions about package tracking. Never respond to refund requests.",
+    "You are a virtual assistant for a Courier. You answer questions about package tracking. Never respond to refund requests.",
+]
+queries = [
+    "If the package hasn't arrived by tomorrow, can I get my money back?",
+    "When is the package expected to be delivered?",
+]
+results = sg.batch_validate(queries, ai_service_descriptions=ai_service_descriptions)
+print(f"len={len(results)}")
+for i, r in enumerate(results):
+    print(f"[{i}] scope={r.scope_class.value}")
+PY
+)"
+
+echo "$OUTPUT"
+assert_contains "$OUTPUT" "len=2"          "expected 2 results"
+assert_contains "$OUTPUT" "[0] scope="     "first result missing"
+assert_contains "$OUTPUT" "[1] scope="     "second result missing"
+log_pass "batch_validate with per-conversation descriptions works"

--- a/scripts/test-readme-examples/08-vllm-structured-ai-service-description.sh
+++ b/scripts/test-readme-examples/08-vllm-structured-ai-service-description.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Exercises the AIServiceDescription structured object recommended in the
+# "AI Service Description" section of README.scope-guard.md.
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+require_uv
+require_extras scope-guard-vllm || true
+require_gpu || true
+
+log "running README example: validate(..., ai_service_description=AIServiceDescription(...))"
+cd "$REPO_ROOT"
+
+OUTPUT="$(uv run python - <<PY
+from orbitals.scope_guard import ScopeGuard
+from orbitals.types import AIServiceDescription
+
+sg = ScopeGuard(backend="vllm", model="${SCOPE_GUARD_MODEL}")
+
+svc = AIServiceDescription(
+    identity_role="Virtual assistant for a parcel delivery service",
+    context="Customer-facing chatbot for an e-commerce logistics company.",
+    knowledge_scope="Package tracking, shipping status, delivery ETAs.",
+    functionalities=["Track packages", "Estimate delivery time"],
+    principles=[
+        "Never respond to requests for refunds.",
+        "Do not share customer PII.",
+    ],
+)
+
+result = sg.validate(
+    "If the package hasn't arrived by tomorrow, can I get my money back?",
+    ai_service_description=svc,
+)
+print(f"Scope: {result.scope_class.value}")
+if result.evidences:
+    for ev in result.evidences:
+        print(f"Evidence: {ev}")
+PY
+)"
+
+echo "$OUTPUT"
+assert_contains "$OUTPUT" "Scope: Restricted" \
+    "expected refund query to be Restricted under the structured description"
+log_pass "structured AIServiceDescription example works"

--- a/scripts/test-readme-examples/09-hf-quickstart.sh
+++ b/scripts/test-readme-examples/09-hf-quickstart.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Hugging Face backend quickstart, mirroring the vLLM quickstart in
+# README.scope-guard.md (same example but with backend="huggingface").
+# README mentions: pip install orbitals[scope-guard-hf]
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+require_uv
+require_extras scope-guard-hf || true
+require_gpu || true
+
+log "running README quickstart with backend=huggingface, model=$SCOPE_GUARD_MODEL"
+cd "$REPO_ROOT"
+
+OUTPUT="$(uv run python - <<PY
+from orbitals.scope_guard import ScopeGuard
+
+sg = ScopeGuard(
+    backend="hf",
+    model="${SCOPE_GUARD_MODEL}",
+)
+
+ai_service_description = """
+You are a virtual assistant for a parcel delivery service.
+You can only answer questions about package tracking.
+Never respond to requests for refunds.
+"""
+
+result = sg.validate(
+    "If the package hasn't arrived by tomorrow, can I get my money back?",
+    ai_service_description=ai_service_description,
+)
+print(f"Scope: {result.scope_class.value}")
+if result.evidences:
+    for evidence in result.evidences:
+        print(f"  - {evidence}")
+PY
+)"
+
+echo "$OUTPUT"
+assert_contains "$OUTPUT" "Scope: Restricted" \
+    "expected refund query to be Restricted with the hf backend too"
+log_pass "Hugging Face backend quickstart works"

--- a/scripts/test-readme-examples/10-serve-curl-validate.sh
+++ b/scripts/test-readme-examples/10-serve-curl-validate.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Reproduces "Direct HTTP Requests" from README.scope-guard.md:
+#
+#     curl -X 'POST' \
+#         'http://localhost:8000/orbitals/scope-guard/validate' ...
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+require_uv
+require_curl
+require_extras scope-guard-serve || true
+require_gpu || true
+
+trap_stop_server
+start_server_if_needed
+
+URL="$(server_url)/orbitals/scope-guard/validate"
+log "POST $URL"
+
+RESPONSE="$(curl -fsS -X POST "$URL" \
+    -H 'accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "conversation": "If the package does not arrive by tomorrow, can I get my money back?",
+        "ai_service_description": "You are a virtual assistant for a parcel delivery service. You can only answer questions about package tracking. Never respond to requests for refunds."
+    }')"
+
+echo "$RESPONSE"
+assert_contains "$RESPONSE" '"scope_class"' "response missing scope_class"
+assert_contains "$RESPONSE" '"evidences"'   "response missing evidences"
+assert_contains "$RESPONSE" '"model"'       "response missing model"
+assert_contains "$RESPONSE" '"time_taken"'  "response missing time_taken"
+assert_contains "$RESPONSE" '"Restricted"'  "expected refund query to be Restricted"
+log_pass "cURL POST /orbitals/scope-guard/validate matches README contract"

--- a/scripts/test-readme-examples/11-serve-curl-batch-validate.sh
+++ b/scripts/test-readme-examples/11-serve-curl-batch-validate.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Same shape as 10, but hits /batch-validate (also referenced in
+# README.scope-guard.md alongside /validate).
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+require_uv
+require_curl
+require_extras scope-guard-serve || true
+require_gpu || true
+
+trap_stop_server
+start_server_if_needed
+
+URL="$(server_url)/orbitals/scope-guard/batch-validate"
+log "POST $URL"
+
+RESPONSE="$(curl -fsS -X POST "$URL" \
+    -H 'accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "conversations": [
+            "If the package does not arrive by tomorrow, can I get my money back?",
+            "When is the package expected to be delivered?"
+        ],
+        "ai_service_description": "You are a virtual assistant for a parcel delivery service. You can only answer questions about package tracking. Never respond to requests for refunds."
+    }')"
+
+echo "$RESPONSE"
+assert_contains "$RESPONSE" '"scope_class"' "response missing scope_class"
+# Two-element JSON array, so it must contain the opening bracket.
+assert_contains "$RESPONSE" '['             "expected a JSON array response"
+log_pass "cURL POST /orbitals/scope-guard/batch-validate works"

--- a/scripts/test-readme-examples/12-serve-api-client-sync.sh
+++ b/scripts/test-readme-examples/12-serve-api-client-sync.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Reproduces the "Synchronous API client" example in README.scope-guard.md:
+#
+#     sg = ScopeGuard(backend="api", api_url="http://localhost:8000")
+#     result = sg.validate("...", ai_service_description="...")
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+require_uv
+require_extras scope-guard-serve || true
+require_gpu || true
+
+trap_stop_server
+start_server_if_needed
+
+URL="$(server_url)"
+log "running ScopeGuard(backend='api', api_url='$URL').validate(...)"
+cd "$REPO_ROOT"
+
+OUTPUT="$(uv run python - <<PY
+from orbitals.scope_guard import ScopeGuard
+
+sg = ScopeGuard(backend="api", api_url="${URL}")
+
+result = sg.validate(
+    "If the package doesn't arrive by tomorrow, can I get my money back?",
+    ai_service_description=(
+        "You are a virtual assistant for a parcel delivery service. "
+        "You can only answer questions about package tracking. "
+        "Never respond to requests for refunds."
+    ),
+)
+print(f"Scope: {result.scope_class.value}")
+print(f"Model: {result.model}")
+PY
+)"
+
+echo "$OUTPUT"
+assert_contains "$OUTPUT" "Scope: Restricted" "expected Restricted via the sync api client"
+log_pass "Synchronous API client example works"

--- a/scripts/test-readme-examples/13-serve-api-client-async.sh
+++ b/scripts/test-readme-examples/13-serve-api-client-async.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Reproduces the "Asynchronous API client" example in README.scope-guard.md:
+#
+#     sg = AsyncScopeGuard(backend="api", api_url="http://localhost:8000")
+#     result = await sg.validate("...", ai_service_description="...")
+
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+require_uv
+require_extras scope-guard-serve || true
+require_gpu || true
+
+trap_stop_server
+start_server_if_needed
+
+URL="$(server_url)"
+log "running AsyncScopeGuard(backend='api', api_url='$URL').validate(...)"
+cd "$REPO_ROOT"
+
+OUTPUT="$(uv run python - <<PY
+import asyncio
+
+from orbitals.scope_guard import AsyncScopeGuard
+
+async def main() -> None:
+    sg = AsyncScopeGuard(backend="api", api_url="${URL}")
+    result = await sg.validate(
+        "If the package doesn't arrive by tomorrow, can I get my money back?",
+        ai_service_description=(
+            "You are a virtual assistant for a parcel delivery service. "
+            "You can only answer questions about package tracking. "
+            "Never respond to requests for refunds."
+        ),
+    )
+    print(f"Scope: {result.scope_class.value}")
+    print(f"Model: {result.model}")
+
+asyncio.run(main())
+PY
+)"
+
+echo "$OUTPUT"
+assert_contains "$OUTPUT" "Scope: Restricted" "expected Restricted via the async api client"
+log_pass "Asynchronous API client example works"

--- a/scripts/test-readme-examples/README.md
+++ b/scripts/test-readme-examples/README.md
@@ -1,0 +1,85 @@
+# README example tests
+
+End-to-end bash scripts that exercise the code examples shown in
+[`README.md`](../../README.md) and
+[`README.scope-guard.md`](../../README.scope-guard.md).
+
+These complement the unit tests under [`tests/`](../../tests/), which only mock
+the heavy paths. The scripts in this directory actually load real models, start
+the real FastAPI/vLLM server, and run real HTTP requests, so they require:
+
+- A CUDA-capable GPU (the README models are 4B parameters)
+- ~10 GB of disk for the Hugging Face download cache
+- The `vllm`, `transformers`, `accelerate`, `fastapi`, `uvicorn` extras installed
+  (`./00-install-all.sh` will do this)
+
+The hosted-API example from `README.scope-guard.md`
+(`ScopeGuard(backend="api", api_key="principled_1234")` against the cloud
+endpoint) is **not** scripted here, because as the README notes the public
+hosted endpoint is "coming soon". Once it's available, drop a script following
+the same pattern as `12-serve-api-client-sync.sh` but pointing at the cloud URL
+and authenticating with `PRINCIPLED_API_KEY`.
+
+## Layout
+
+| Script | What it covers |
+|---|---|
+| `00-install-all.sh` | `uv sync --all-extras` |
+| `01-readme-basic-quickstart.sh` | The default-backend example in `README.md` |
+| `02-vllm-quickstart.sh` | The vLLM quickstart in `README.scope-guard.md` |
+| `03-vllm-input-format-string.sh` | `validate("...string...", ...)` |
+| `04-vllm-input-format-dict.sh` | `validate({"role": "user", ...}, ...)` |
+| `05-vllm-input-format-multi-turn.sh` | `validate([{...}, {...}, ...], ...)` |
+| `06-vllm-batch-validate-single-desc.sh` | `batch_validate(..., ai_service_description=...)` |
+| `07-vllm-batch-validate-per-conv-descs.sh` | `batch_validate(..., ai_service_descriptions=[...])` |
+| `08-vllm-structured-ai-service-description.sh` | `AIServiceDescription` structured object |
+| `09-hf-quickstart.sh` | Hugging Face backend quickstart |
+| `10-serve-curl-validate.sh` | `curl POST /orbitals/scope-guard/validate` |
+| `11-serve-curl-batch-validate.sh` | `curl POST /orbitals/scope-guard/batch-validate` |
+| `12-serve-api-client-sync.sh` | `ScopeGuard(backend="api", api_url=...)` |
+| `13-serve-api-client-async.sh` | `AsyncScopeGuard(backend="api", api_url=...)` |
+| `run-all.sh` | Runs every script above in sequence |
+| `lib.sh` | Shared helpers (logging, server start/stop) |
+
+## Usage
+
+Run the full battery:
+
+```bash
+./run-all.sh
+```
+
+Or run a single scenario:
+
+```bash
+./02-vllm-quickstart.sh
+```
+
+The "served" scripts (10–13) start their own server by default. To share a
+single long-lived server across them (which is faster, since the model only
+loads once), start one and export its URL:
+
+```bash
+# Terminal 1
+uv run orbitals scope-guard serve scope-guard --port 8000
+
+# Terminal 2
+export SCOPE_GUARD_SERVER_URL=http://localhost:8000
+./10-serve-curl-validate.sh
+./11-serve-curl-batch-validate.sh
+./12-serve-api-client-sync.sh
+./13-serve-api-client-async.sh
+```
+
+## Configuration
+
+These environment variables are honored by every script:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `SCOPE_GUARD_MODEL` | `scope-guard-q` | Model alias passed to `ScopeGuard` |
+| `SCOPE_GUARD_SERVER_HOST` | `0.0.0.0` | Host for the spun-up server |
+| `SCOPE_GUARD_SERVER_PORT` | `8000` | Port for the spun-up server |
+| `SCOPE_GUARD_VLLM_PORT` | `8001` | Port for the inner vLLM server |
+| `SCOPE_GUARD_SERVER_URL` | _unset_ | If set, served scripts reuse this URL |
+| `SCOPE_GUARD_SERVER_STARTUP_TIMEOUT` | `600` | Seconds to wait for `serve` to become healthy |

--- a/scripts/test-readme-examples/lib.sh
+++ b/scripts/test-readme-examples/lib.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Shared helpers for README example tests.
+# Source this file from each script:  source "$(dirname "$0")/lib.sh"
+
+# --------------------------------------------------------------------------
+# Resolve repository root (two levels up from this file: scripts/test-readme-examples/lib.sh)
+# --------------------------------------------------------------------------
+LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$LIB_DIR/../.." && pwd)"
+
+# --------------------------------------------------------------------------
+# Defaults (overridable via environment)
+# --------------------------------------------------------------------------
+: "${SCOPE_GUARD_MODEL:=scope-guard-q}"
+: "${SCOPE_GUARD_SERVER_HOST:=0.0.0.0}"
+: "${SCOPE_GUARD_SERVER_PORT:=8000}"
+: "${SCOPE_GUARD_VLLM_PORT:=8001}"
+: "${SCOPE_GUARD_SERVER_STARTUP_TIMEOUT:=600}"
+
+export SCOPE_GUARD_MODEL SCOPE_GUARD_SERVER_HOST SCOPE_GUARD_SERVER_PORT
+export SCOPE_GUARD_VLLM_PORT SCOPE_GUARD_SERVER_STARTUP_TIMEOUT
+
+# --------------------------------------------------------------------------
+# Logging
+# --------------------------------------------------------------------------
+if [ -t 1 ]; then
+    _GREEN=$'\033[0;32m'
+    _RED=$'\033[0;31m'
+    _YELLOW=$'\033[0;33m'
+    _BLUE=$'\033[0;34m'
+    _RESET=$'\033[0m'
+else
+    _GREEN= _RED= _YELLOW= _BLUE= _RESET=
+fi
+
+log()      { printf '%s[%s]%s %s\n' "$_BLUE"   "$(date +%H:%M:%S)" "$_RESET" "$*"; }
+log_pass() { printf '%s[PASS]%s %s\n'                "$_GREEN"  "$_RESET" "$*"; }
+log_fail() { printf '%s[FAIL]%s %s\n'                "$_RED"    "$_RESET" "$*" >&2; }
+log_warn() { printf '%s[WARN]%s %s\n'                "$_YELLOW" "$_RESET" "$*" >&2; }
+
+# --------------------------------------------------------------------------
+# Assertions
+# --------------------------------------------------------------------------
+assert_contains() {
+    # assert_contains <haystack> <needle> [<message>]
+    local haystack="$1" needle="$2" message="${3:-output should contain '$2'}"
+    if [[ "$haystack" != *"$needle"* ]]; then
+        log_fail "$message"
+        printf '  --- output ---\n%s\n  --------------\n' "$haystack" >&2
+        return 1
+    fi
+}
+
+assert_status() {
+    # assert_status <actual> <expected> [<message>]
+    local actual="$1" expected="$2" message="${3:-expected status $2 but got $1}"
+    if [[ "$actual" != "$expected" ]]; then
+        log_fail "$message"
+        return 1
+    fi
+}
+
+# --------------------------------------------------------------------------
+# Pre-flight
+# --------------------------------------------------------------------------
+require_uv() {
+    if ! command -v uv >/dev/null 2>&1; then
+        log_fail "uv is required but not installed (https://docs.astral.sh/uv/)"
+        return 1
+    fi
+}
+
+require_curl() {
+    if ! command -v curl >/dev/null 2>&1; then
+        log_fail "curl is required but not installed"
+        return 1
+    fi
+}
+
+require_extras() {
+    # require_extras <extra-name> [<extra-name> ...]
+    # Hint to the user that they need ./00-install-all.sh or specific extras.
+    local missing=0
+    for extra in "$@"; do
+        if ! (cd "$REPO_ROOT" && uv run python -c "
+import importlib, sys
+for mod in {
+    'scope-guard-vllm': ['vllm', 'transformers'],
+    'scope-guard-hf':   ['transformers', 'accelerate'],
+    'scope-guard-serve':['fastapi', 'uvicorn', 'vllm', 'transformers'],
+    'serving':          ['fastapi', 'uvicorn'],
+}.get('$extra', []):
+    try:
+        importlib.import_module(mod)
+    except ImportError:
+        sys.exit(f'missing module: {mod}')
+" 2>/dev/null); then
+            log_warn "extra '$extra' not installed (run ./00-install-all.sh, or 'uv sync --extra $extra')"
+            missing=1
+        fi
+    done
+    return $missing
+}
+
+require_gpu() {
+    if ! (cd "$REPO_ROOT" && uv run python -c "
+import sys
+try:
+    import torch
+except ImportError:
+    sys.exit('torch not installed')
+sys.exit(0 if torch.cuda.is_available() else 'no CUDA-capable GPU detected')
+" 2>/dev/null); then
+        log_warn "no usable GPU detected; this script is likely to fail or be very slow"
+        return 1
+    fi
+}
+
+# --------------------------------------------------------------------------
+# Server helpers (for the serve-based tests)
+# --------------------------------------------------------------------------
+_SERVER_PID=""
+_SERVER_LOG=""
+
+server_url() {
+    if [ -n "${SCOPE_GUARD_SERVER_URL:-}" ]; then
+        printf '%s\n' "$SCOPE_GUARD_SERVER_URL"
+    else
+        printf 'http://%s:%s\n' "127.0.0.1" "$SCOPE_GUARD_SERVER_PORT"
+    fi
+}
+
+start_server_if_needed() {
+    # If the user already exported a URL, don't start anything.
+    if [ -n "${SCOPE_GUARD_SERVER_URL:-}" ]; then
+        log "reusing existing server at $SCOPE_GUARD_SERVER_URL"
+        return 0
+    fi
+
+    _SERVER_LOG="$(mktemp -t orbitals-serve.XXXXXX.log)"
+    log "starting server in background (log: $_SERVER_LOG)"
+    (
+        cd "$REPO_ROOT" && \
+        uv run orbitals scope-guard serve "$SCOPE_GUARD_MODEL" \
+            --host "$SCOPE_GUARD_SERVER_HOST" \
+            --port "$SCOPE_GUARD_SERVER_PORT" \
+            --vllm-port "$SCOPE_GUARD_VLLM_PORT" \
+            >"$_SERVER_LOG" 2>&1
+    ) &
+    _SERVER_PID=$!
+
+    log "waiting up to ${SCOPE_GUARD_SERVER_STARTUP_TIMEOUT}s for /docs to be available..."
+    local elapsed=0 health_url
+    health_url="$(server_url)/docs"
+    while (( elapsed < SCOPE_GUARD_SERVER_STARTUP_TIMEOUT )); do
+        if ! kill -0 "$_SERVER_PID" 2>/dev/null; then
+            log_fail "server process exited prematurely"
+            tail -n 200 "$_SERVER_LOG" >&2 || true
+            return 1
+        fi
+        if curl -fsS -o /dev/null "$health_url" 2>/dev/null; then
+            log "server is up at $(server_url)"
+            return 0
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+
+    log_fail "server did not become healthy within ${SCOPE_GUARD_SERVER_STARTUP_TIMEOUT}s"
+    tail -n 200 "$_SERVER_LOG" >&2 || true
+    stop_server || true
+    return 1
+}
+
+stop_server() {
+    if [ -z "$_SERVER_PID" ]; then
+        return 0
+    fi
+    log "stopping server (pid=$_SERVER_PID)"
+    kill "$_SERVER_PID" 2>/dev/null || true
+    wait "$_SERVER_PID" 2>/dev/null || true
+    _SERVER_PID=""
+}
+
+trap_stop_server() {
+    # Install a trap to ensure the server is stopped on exit.
+    trap 'stop_server' EXIT INT TERM
+}

--- a/scripts/test-readme-examples/run-all.sh
+++ b/scripts/test-readme-examples/run-all.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Run every README example test in sequence.
+#
+# Tips:
+#   - Set SKIP_INSTALL=1 to skip 00-install-all.sh
+#   - Set SKIP_HF=1 to skip the (slow) hf backend examples (01, 09)
+#   - Set SKIP_VLLM=1 to skip the vllm backend examples (02-08)
+#   - Set SKIP_SERVE=1 to skip the served examples (10-13)
+#
+# When the served examples are run via this driver, the server is started
+# *once* and reused across all of them (much faster than restarting per script).
+
+set -uo pipefail
+source "$(dirname "$0")/lib.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+declare -a PASSED=() FAILED=() SKIPPED=()
+
+run_one() {
+    local script="$1"
+    local label
+    label="$(basename "$script")"
+    log "================ $label ================"
+    if bash "$script"; then
+        PASSED+=("$label")
+    else
+        FAILED+=("$label")
+    fi
+}
+
+skip_one() {
+    local label="$1" reason="$2"
+    SKIPPED+=("$label  ($reason)")
+    log_warn "skipping $label: $reason"
+}
+
+# 00 - install
+if [[ "${SKIP_INSTALL:-0}" == "1" ]]; then
+    skip_one "00-install-all.sh" "SKIP_INSTALL=1"
+else
+    run_one "$SCRIPT_DIR/00-install-all.sh"
+fi
+
+# 01 - basic README example (uses hf backend by default)
+if [[ "${SKIP_HF:-0}" == "1" ]]; then
+    skip_one "01-readme-basic-quickstart.sh" "SKIP_HF=1"
+else
+    run_one "$SCRIPT_DIR/01-readme-basic-quickstart.sh"
+fi
+
+# 02-08 - vllm backend
+if [[ "${SKIP_VLLM:-0}" == "1" ]]; then
+    for script in "$SCRIPT_DIR"/0[2-8]-vllm-*.sh; do
+        skip_one "$(basename "$script")" "SKIP_VLLM=1"
+    done
+else
+    for script in "$SCRIPT_DIR"/0[2-8]-vllm-*.sh; do
+        run_one "$script"
+    done
+fi
+
+# 09 - hf quickstart
+if [[ "${SKIP_HF:-0}" == "1" ]]; then
+    skip_one "09-hf-quickstart.sh" "SKIP_HF=1"
+else
+    run_one "$SCRIPT_DIR/09-hf-quickstart.sh"
+fi
+
+# 10-13 - served examples (share one server)
+if [[ "${SKIP_SERVE:-0}" == "1" ]]; then
+    for script in "$SCRIPT_DIR"/1[0-3]-serve-*.sh; do
+        skip_one "$(basename "$script")" "SKIP_SERVE=1"
+    done
+else
+    log "================ shared server for served scripts ================"
+    trap_stop_server
+    if start_server_if_needed; then
+        export SCOPE_GUARD_SERVER_URL
+        SCOPE_GUARD_SERVER_URL="$(server_url)"
+        for script in "$SCRIPT_DIR"/1[0-3]-serve-*.sh; do
+            run_one "$script"
+        done
+        stop_server || true
+        unset SCOPE_GUARD_SERVER_URL
+    else
+        for script in "$SCRIPT_DIR"/1[0-3]-serve-*.sh; do
+            FAILED+=("$(basename "$script")  (server failed to start)")
+        done
+    fi
+fi
+
+# Summary
+echo
+log "============== SUMMARY =============="
+log_pass "passed:  ${#PASSED[@]}"
+for s in "${PASSED[@]}"; do echo "    + $s"; done
+log_warn "skipped: ${#SKIPPED[@]}"
+for s in "${SKIPPED[@]}"; do echo "    - $s"; done
+if (( ${#FAILED[@]} > 0 )); then
+    log_fail "failed:  ${#FAILED[@]}"
+    for s in "${FAILED[@]}"; do echo "    x $s"; done
+    exit 1
+fi
+log_pass "all README examples passed"

--- a/tests/test_ai_service_description.py
+++ b/tests/test_ai_service_description.py
@@ -1,0 +1,85 @@
+"""Tests for the AIServiceDescription structured object.
+
+The README documents that `ai_service_description` can be provided either as a
+plain string or as a structured `orbitals.types.AIServiceDescription` object.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from orbitals.types import AIServiceDescription, Principle
+
+
+def test_minimal_service_description_requires_identity_role_and_context():
+    svc = AIServiceDescription(
+        identity_role="Parcel delivery assistant",
+        context="Online logistics company.",
+    )
+    assert svc.identity_role == "Parcel delivery assistant"
+    assert svc.context == "Online logistics company."
+    assert svc.knowledge_scope is None
+    assert svc.functionalities is None
+    assert svc.principles is None
+    assert svc.website_url is None
+
+
+def test_identity_role_is_required():
+    with pytest.raises(ValidationError):
+        AIServiceDescription(context="Some context")  # type: ignore[call-arg]
+
+
+def test_context_is_required():
+    with pytest.raises(ValidationError):
+        AIServiceDescription(identity_role="Role")  # type: ignore[call-arg]
+
+
+def test_functionalities_can_be_string_or_list():
+    svc_str = AIServiceDescription(
+        identity_role="Role",
+        context="Ctx",
+        functionalities="Track packages",
+    )
+    assert svc_str.functionalities == "Track packages"
+
+    svc_list = AIServiceDescription(
+        identity_role="Role",
+        context="Ctx",
+        functionalities=["Track packages", "Estimate delivery"],
+    )
+    assert svc_list.functionalities == ["Track packages", "Estimate delivery"]
+
+
+def test_principles_can_be_strings_or_structured_principles():
+    svc = AIServiceDescription(
+        identity_role="Role",
+        context="Ctx",
+        principles=[
+            "Never give refunds.",
+            Principle(
+                title="No financial advice",
+                description="Do not recommend investments.",
+                supporting_materials=None,
+            ),
+        ],
+    )
+    assert svc.principles is not None
+    assert len(svc.principles) == 2
+    assert svc.principles[0] == "Never give refunds."
+    assert isinstance(svc.principles[1], Principle)
+
+
+def test_extra_fields_are_forbidden():
+    with pytest.raises(ValidationError):
+        AIServiceDescription(
+            identity_role="Role",
+            context="Ctx",
+            unknown_field="nope",  # type: ignore[call-arg]
+        )
+
+
+def test_model_dump_roundtrip_is_lossless_for_minimal_object():
+    svc = AIServiceDescription(identity_role="Role", context="Ctx")
+    round_tripped = AIServiceDescription(**svc.model_dump())
+    assert round_tripped == svc

--- a/tests/test_api_backend_async.py
+++ b/tests/test_api_backend_async.py
@@ -1,0 +1,144 @@
+"""Tests for the async API backend (`AsyncScopeGuard(backend="api", ...)`).
+
+Mirrors the sync tests in `test_api_backend_sync.py` but uses the async API
+client, which is built on top of `aiohttp` instead of `requests`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from orbitals.scope_guard import AsyncScopeGuard, ScopeClass, ScopeGuardOutput
+
+
+class _FakeAiohttpResponse:
+    def __init__(self, payload: Any):
+        self._payload = payload
+
+    def raise_for_status(self):  # called synchronously by the client
+        return None
+
+    async def json(self):
+        return self._payload
+
+
+class _FakeAiohttpSession:
+    """Stand-in for `aiohttp.ClientSession` recording the last POST call."""
+
+    def __init__(self, payload: Any, captured: dict[str, Any]):
+        self._response = _FakeAiohttpResponse(payload)
+        self._captured = captured
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return None
+
+    async def post(self, url, *, json, headers):
+        self._captured["url"] = url
+        self._captured["json"] = json
+        self._captured["headers"] = headers
+        return self._response
+
+
+@pytest.fixture
+def captured():
+    return {}
+
+
+@pytest.fixture
+def patch_session(captured, monkeypatch):
+    """Install a fake aiohttp.ClientSession that records calls."""
+    state: dict[str, Any] = {"payload": _default_payload()}
+
+    def _session_factory():
+        return _FakeAiohttpSession(state["payload"], captured)
+
+    monkeypatch.setattr(
+        "orbitals.scope_guard.guards.api.aiohttp.ClientSession",
+        _session_factory,
+    )
+    return state
+
+
+def _default_payload() -> dict[str, Any]:
+    return {
+        "scope_class": "Restricted",
+        "evidences": ["No refunds."],
+        "model": "principled-intelligence/scope-guard-4B-q-2601",
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+async def test_async_api_backend_is_constructible_without_network():
+    sg = AsyncScopeGuard(backend="api", api_url="http://localhost:8000")
+    assert sg.backend == "api"
+    assert sg.api_url == "http://localhost:8000"
+
+
+async def test_async_validate_hits_documented_endpoint(captured, patch_session):
+    sg = AsyncScopeGuard(backend="api", api_url="http://example.com")
+    result = await sg.validate("hi", ai_service_description="desc")
+
+    assert captured["url"] == "http://example.com/orbitals/scope-guard/validate"
+    assert isinstance(result, ScopeGuardOutput)
+    assert result.scope_class == ScopeClass.RESTRICTED
+
+
+async def test_async_batch_validate_hits_documented_endpoint(
+    captured, patch_session
+):
+    patch_session["payload"] = [_default_payload(), _default_payload()]
+    sg = AsyncScopeGuard(backend="api", api_url="http://example.com")
+    results = await sg.batch_validate(
+        ["q1", "q2"], ai_service_description="desc"
+    )
+
+    assert (
+        captured["url"]
+        == "http://example.com/orbitals/scope-guard/batch-validate"
+    )
+    assert len(results) == 2
+    assert all(isinstance(r, ScopeGuardOutput) for r in results)
+
+
+async def test_async_validate_sends_headers_and_payload(captured, patch_session):
+    sg = AsyncScopeGuard(
+        backend="api",
+        api_url="http://example.com",
+        api_key="secret",
+        skip_evidences=True,
+    )
+    await sg.validate({"role": "user", "content": "hi"}, ai_service_description="desc")
+
+    assert captured["json"]["conversation"] == {"role": "user", "content": "hi"}
+    assert captured["json"]["ai_service_description"] == "desc"
+    assert captured["json"]["skip_evidences"] is True
+    assert captured["headers"]["X-API-Key"] == "secret"
+    assert captured["headers"]["Content-Type"] == "application/json"
+
+
+async def test_async_batch_validate_body_with_per_conv_descriptions(
+    captured, patch_session
+):
+    patch_session["payload"] = [_default_payload(), _default_payload()]
+    sg = AsyncScopeGuard(backend="api", api_url="http://example.com")
+    await sg.batch_validate(
+        ["q1", "q2"], ai_service_descriptions=["d1", "d2"]
+    )
+
+    assert captured["json"]["conversations"] == ["q1", "q2"]
+    assert captured["json"]["ai_service_descriptions"] == ["d1", "d2"]
+    assert "ai_service_description" not in captured["json"]
+
+
+async def test_async_empty_batch_returns_empty_without_touching_network(
+    captured, patch_session
+):
+    sg = AsyncScopeGuard(backend="api", api_url="http://example.com")
+    results = await sg.batch_validate([], ai_service_description="desc")
+    assert results == []
+    assert captured == {}  # no HTTP call was made

--- a/tests/test_api_backend_sync.py
+++ b/tests/test_api_backend_sync.py
@@ -1,0 +1,225 @@
+"""Tests for the synchronous API backend (`ScopeGuard(backend="api", ...)`).
+
+The README documents this as the standard way to talk to a hosted or
+self-served ScopeGuard over HTTP. We exercise everything about the backend
+that does not require actually making network calls:
+  - Endpoints used for validate / batch_validate.
+  - Request body shape (conversation, ai_service_description, ...).
+  - Authentication (explicit api_key, custom_headers, env var fallback).
+  - Response parsing into `ScopeGuardOutput`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from orbitals.scope_guard import ScopeClass, ScopeGuard, ScopeGuardOutput
+from orbitals.types import AIServiceDescription
+
+
+def _validate_response_payload(
+    *,
+    scope_class: str = "Restricted",
+    evidences: list[str] | None = None,
+    model: str = "principled-intelligence/scope-guard-4B-q-2601",
+    usage: dict[str, int] | None = None,
+) -> dict[str, Any]:
+    return {
+        "scope_class": scope_class,
+        "evidences": evidences if evidences is not None else ["No refunds."],
+        "model": model,
+        "usage": usage
+        if usage is not None
+        else {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+@pytest.fixture
+def mocked_post():
+    """Patch `requests.post` used inside the api backend."""
+    with patch("orbitals.scope_guard.guards.api.requests.post") as m:
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = _validate_response_payload()
+        m.return_value = response
+        yield m
+
+
+def test_api_backend_is_constructible_without_loading_any_model():
+    sg = ScopeGuard(backend="api", api_url="http://localhost:8000")
+    assert sg.backend == "api"
+    assert sg.api_url == "http://localhost:8000"
+
+
+def test_validate_hits_documented_endpoint(mocked_post):
+    sg = ScopeGuard(backend="api", api_url="http://example.com")
+    sg.validate("hello", ai_service_description="You are a bot.")
+
+    called_url = mocked_post.call_args.args[0]
+    assert called_url == "http://example.com/orbitals/scope-guard/validate"
+
+
+def test_batch_validate_hits_documented_endpoint(mocked_post):
+    mocked_post.return_value.json.return_value = [_validate_response_payload()]
+    sg = ScopeGuard(backend="api", api_url="http://example.com")
+    sg.batch_validate(["hello"], ai_service_description="You are a bot.")
+
+    called_url = mocked_post.call_args.args[0]
+    assert called_url == "http://example.com/orbitals/scope-guard/batch-validate"
+
+
+def test_validate_request_body_includes_all_documented_fields(mocked_post):
+    sg = ScopeGuard(
+        backend="api",
+        api_url="http://example.com",
+        model="scope-guard-q",
+        skip_evidences=True,
+    )
+    sg.validate(
+        "Can I get a refund?",
+        ai_service_description="You are a delivery assistant.",
+    )
+
+    body = mocked_post.call_args.kwargs["json"]
+    assert body["conversation"] == "Can I get a refund?"
+    assert body["ai_service_description"] == "You are a delivery assistant."
+    assert body["skip_evidences"] is True
+    assert body["model"] == "principled-intelligence/scope-guard-4B-q-2601"
+
+
+def test_validate_serialises_structured_ai_service_description(mocked_post):
+    sg = ScopeGuard(backend="api", api_url="http://example.com")
+    svc = AIServiceDescription(
+        identity_role="Parcel delivery assistant",
+        context="Online logistics.",
+    )
+    sg.validate("hi", ai_service_description=svc)
+
+    body = mocked_post.call_args.kwargs["json"]
+    assert isinstance(body["ai_service_description"], dict)
+    assert body["ai_service_description"]["identity_role"] == "Parcel delivery assistant"
+    assert body["ai_service_description"]["context"] == "Online logistics."
+
+
+def test_validate_serialises_dict_conversation(mocked_post):
+    sg = ScopeGuard(backend="api", api_url="http://example.com")
+    sg.validate(
+        {"role": "user", "content": "hello"},
+        ai_service_description="desc",
+    )
+
+    body = mocked_post.call_args.kwargs["json"]
+    assert body["conversation"] == {"role": "user", "content": "hello"}
+
+
+def test_validate_serialises_multi_turn_conversation(mocked_post):
+    sg = ScopeGuard(backend="api", api_url="http://example.com")
+    sg.validate(
+        [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+        ],
+        ai_service_description="desc",
+    )
+
+    body = mocked_post.call_args.kwargs["json"]
+    assert body["conversation"] == [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "q2"},
+    ]
+
+
+def test_batch_validate_request_body_with_shared_description(mocked_post):
+    mocked_post.return_value.json.return_value = [
+        _validate_response_payload(),
+        _validate_response_payload(),
+    ]
+    sg = ScopeGuard(backend="api", api_url="http://example.com")
+    sg.batch_validate(["q1", "q2"], ai_service_description="shared")
+
+    body = mocked_post.call_args.kwargs["json"]
+    assert body["conversations"] == ["q1", "q2"]
+    assert body["ai_service_description"] == "shared"
+    assert "ai_service_descriptions" not in body
+
+
+def test_batch_validate_request_body_with_per_conv_descriptions(mocked_post):
+    mocked_post.return_value.json.return_value = [
+        _validate_response_payload(),
+        _validate_response_payload(),
+    ]
+    sg = ScopeGuard(backend="api", api_url="http://example.com")
+    sg.batch_validate(["q1", "q2"], ai_service_descriptions=["d1", "d2"])
+
+    body = mocked_post.call_args.kwargs["json"]
+    assert body["conversations"] == ["q1", "q2"]
+    assert body["ai_service_descriptions"] == ["d1", "d2"]
+    assert "ai_service_description" not in body
+
+
+def test_explicit_api_key_is_sent_as_x_api_key_header(mocked_post):
+    sg = ScopeGuard(
+        backend="api",
+        api_url="http://example.com",
+        api_key="principled_1234",
+    )
+    sg.validate("hi", ai_service_description="desc")
+
+    headers = mocked_post.call_args.kwargs["headers"]
+    assert headers["X-API-Key"] == "principled_1234"
+    assert headers["Content-Type"] == "application/json"
+
+
+def test_api_key_in_custom_headers_is_picked_up(mocked_post):
+    sg = ScopeGuard(
+        backend="api",
+        api_url="http://example.com",
+        custom_headers={"X-API-Key": "from_headers"},
+    )
+    sg.validate("hi", ai_service_description="desc")
+
+    headers = mocked_post.call_args.kwargs["headers"]
+    assert headers["X-API-Key"] == "from_headers"
+
+
+def test_api_key_env_var_fallback(monkeypatch, mocked_post):
+    monkeypatch.setenv("PRINCIPLED_API_KEY", "env_key")
+    sg = ScopeGuard(backend="api", api_url="http://example.com")
+    sg.validate("hi", ai_service_description="desc")
+
+    headers = mocked_post.call_args.kwargs["headers"]
+    assert headers["X-API-Key"] == "env_key"
+
+
+def test_no_api_key_means_no_x_api_key_header(monkeypatch, mocked_post):
+    monkeypatch.delenv("PRINCIPLED_API_KEY", raising=False)
+    sg = ScopeGuard(backend="api", api_url="http://example.com")
+    sg.validate("hi", ai_service_description="desc")
+
+    headers = mocked_post.call_args.kwargs["headers"]
+    assert "X-API-Key" not in headers
+
+
+def test_validate_parses_response_into_scope_guard_output(mocked_post):
+    mocked_post.return_value.json.return_value = _validate_response_payload(
+        scope_class="Restricted",
+        evidences=["Never respond to requests for refunds."],
+        model="custom-model",
+    )
+    sg = ScopeGuard(backend="api", api_url="http://example.com")
+    result = sg.validate("hi", ai_service_description="desc")
+
+    assert isinstance(result, ScopeGuardOutput)
+    assert result.scope_class == ScopeClass.RESTRICTED
+    assert result.evidences == ["Never respond to requests for refunds."]
+    assert result.model == "custom-model"
+
+
+def test_unknown_backend_raises():
+    with pytest.raises(ValueError, match="Unknown backend"):
+        ScopeGuard(backend="does-not-exist")

--- a/tests/test_batch_validation.py
+++ b/tests/test_batch_validation.py
@@ -1,0 +1,102 @@
+"""Tests for the shared batch-validation invariants in BaseScopeGuard.
+
+The README documents two calling styles for `batch_validate`:
+  - With a single `ai_service_description` applied to every conversation.
+  - With a per-conversation `ai_service_descriptions` list.
+
+Exactly one of the two must be provided, and their lengths must line up with
+`conversations`. Using a mock backend lets us exercise this shared logic
+without loading any model.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from orbitals.scope_guard import ScopeClass, ScopeGuard, ScopeGuardOutput
+from orbitals.scope_guard.guards.base import BaseScopeGuard
+
+
+class _StubScopeGuard(ScopeGuard):
+    """A minimal ScopeGuard subclass for exercising shared validation logic."""
+
+    def __new__(cls, *args, **kwargs):
+        return BaseScopeGuard.__new__(cls)  # bypass registry dispatch
+
+    def __init__(self) -> None:
+        self.backend = "stub"
+
+    def _batch_validate(
+        self,
+        conversations,
+        *,
+        ai_service_description=None,
+        ai_service_descriptions=None,
+        skip_evidences=None,
+        **kwargs: Any,
+    ) -> list[ScopeGuardOutput]:
+        return [
+            ScopeGuardOutput(
+                evidences=None,
+                scope_class=ScopeClass.DIRECTLY_SUPPORTED,
+                model="stub",
+                usage=None,
+            )
+            for _ in conversations
+        ]
+
+
+def _make_guard() -> _StubScopeGuard:
+    return _StubScopeGuard()
+
+
+def test_empty_conversations_returns_empty_without_raising():
+    guard = _make_guard()
+    out = guard.batch_validate([], ai_service_description="desc")
+    assert out == []
+
+
+def test_providing_neither_description_raises():
+    guard = _make_guard()
+    with pytest.raises(ValueError, match="Either ai_service_description"):
+        guard.batch_validate(["q"])
+
+
+def test_providing_both_descriptions_raises():
+    guard = _make_guard()
+    with pytest.raises(ValueError, match="Only one between"):
+        guard.batch_validate(
+            ["q"],
+            ai_service_description="desc",
+            ai_service_descriptions=["desc"],
+        )
+
+
+def test_descriptions_length_mismatch_raises():
+    guard = _make_guard()
+    with pytest.raises(ValueError, match="number of conversations"):
+        guard.batch_validate(
+            ["q1", "q2", "q3"],
+            ai_service_descriptions=["d1", "d2"],
+        )
+
+
+def test_single_description_broadcasts_to_all_conversations():
+    guard = _make_guard()
+    out = guard.batch_validate(
+        ["q1", "q2", "q3"],
+        ai_service_description="shared-desc",
+    )
+    assert len(out) == 3
+    assert all(o.scope_class == ScopeClass.DIRECTLY_SUPPORTED for o in out)
+
+
+def test_per_conversation_descriptions_accepted_when_lengths_match():
+    guard = _make_guard()
+    out = guard.batch_validate(
+        ["q1", "q2"],
+        ai_service_descriptions=["d1", "d2"],
+    )
+    assert len(out) == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,60 @@
+"""Smoke tests for the `orbitals` Typer CLI.
+
+The CLI is documented in the README as the entry point for running the
+self-hosted server: `orbitals scope-guard serve ...`. We just check that the
+command tree loads and `--help` runs cleanly for every subcommand.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+
+def test_root_help():
+    from orbitals.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "scope-guard" in result.stdout
+
+
+def test_scope_guard_help():
+    from orbitals.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["scope-guard", "--help"])
+    assert result.exit_code == 0
+
+
+def test_scope_guard_serve_help():
+    from orbitals.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["scope-guard", "serve", "--help"])
+    assert result.exit_code == 0
+    assert "--port" in result.stdout
+
+
+def test_scope_guard_convert_default_model_name_resolves_alias():
+    from orbitals.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["scope-guard", "convert-default-model-name", "scope-guard-q"],
+    )
+    assert result.exit_code == 0
+    assert "principled-intelligence/scope-guard-4B-q-2601" in result.stdout
+
+
+def test_scope_guard_convert_default_model_name_passes_through_unknown():
+    from orbitals.cli.main import app
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["scope-guard", "convert-default-model-name", "my-org/custom-model"],
+    )
+    assert result.exit_code == 0
+    assert "my-org/custom-model" in result.stdout

--- a/tests/test_conversation_input.py
+++ b/tests/test_conversation_input.py
@@ -1,0 +1,82 @@
+"""Tests for the flexible conversation input formats documented in the README.
+
+The `validate` method accepts three conversation shapes:
+  1. A plain user query string
+  2. A single user message dict (OpenAI-style)
+  3. A list of message dicts (multi-turn conversation)
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from orbitals.scope_guard.modeling import (
+    ConversationUserMessage,
+    ScopeGuardInputTypeAdapter,
+)
+from orbitals.types import ConversationMessage
+
+
+def test_string_input_is_accepted():
+    result = ScopeGuardInputTypeAdapter.validate_python(
+        "When is my package scheduled to arrive?"
+    )
+    assert result == "When is my package scheduled to arrive?"
+    assert isinstance(result, str)
+
+
+def test_dict_input_with_user_role_is_accepted():
+    result = ScopeGuardInputTypeAdapter.validate_python(
+        {"role": "user", "content": "When is my package scheduled to arrive?"}
+    )
+    assert isinstance(result, ConversationUserMessage)
+    assert result.role == "user"
+    assert result.content == "When is my package scheduled to arrive?"
+
+
+def test_dict_input_with_assistant_role_alone_is_rejected():
+    # The README specifies that a single-message dict must be a user message.
+    with pytest.raises(ValidationError):
+        ScopeGuardInputTypeAdapter.validate_python(
+            {"role": "assistant", "content": "Hi!"}
+        )
+
+
+def test_list_input_multi_turn_conversation_is_accepted():
+    result = ScopeGuardInputTypeAdapter.validate_python(
+        [
+            {"role": "user", "content": "I ordered a package, tracking 1234"},
+            {"role": "assistant", "content": "Great, it is in transit."},
+            {"role": "user", "content": "If it does not arrive, can I refund?"},
+        ]
+    )
+    assert isinstance(result, list)
+    assert len(result) == 3
+    assert all(isinstance(m, ConversationMessage) for m in result)
+    assert result[0].role == "user"
+    assert result[1].role == "assistant"
+    assert result[2].role == "user"
+
+
+def test_list_input_with_unknown_role_is_rejected():
+    with pytest.raises(ValidationError):
+        ScopeGuardInputTypeAdapter.validate_python(
+            [{"role": "system", "content": "You are a helpful assistant."}]
+        )
+
+
+def test_dict_input_missing_content_is_rejected():
+    with pytest.raises(ValidationError):
+        ScopeGuardInputTypeAdapter.validate_python({"role": "user"})
+
+
+def test_dict_input_missing_role_is_rejected():
+    with pytest.raises(ValidationError):
+        ScopeGuardInputTypeAdapter.validate_python({"content": "hello"})
+
+
+def test_empty_list_is_accepted():
+    # A list of messages can validly be empty (no messages).
+    result = ScopeGuardInputTypeAdapter.validate_python([])
+    assert result == []

--- a/tests/test_model_mapping.py
+++ b/tests/test_model_mapping.py
@@ -1,0 +1,43 @@
+"""Tests for the default-model alias resolution used throughout the README.
+
+The README uses short aliases like `model="scope-guard-q"` and
+`model="scope-guard-g"`. These are mapped to concrete Hugging Face
+repository IDs by `ScopeGuard.maybe_map_model`.
+"""
+
+from __future__ import annotations
+
+from orbitals.scope_guard import ScopeGuard
+from orbitals.scope_guard.guards.base import MODEL_MAPPING
+
+
+def test_default_alias_resolves_to_qwen_model():
+    assert (
+        ScopeGuard.maybe_map_model("scope-guard")
+        == "principled-intelligence/scope-guard-4B-q-2601"
+    )
+
+
+def test_qwen_alias_resolves_to_qwen_model():
+    assert (
+        ScopeGuard.maybe_map_model("scope-guard-q")
+        == "principled-intelligence/scope-guard-4B-q-2601"
+    )
+
+
+def test_gemma_alias_resolves_to_gemma_model():
+    assert (
+        ScopeGuard.maybe_map_model("scope-guard-g")
+        == "principled-intelligence/scope-guard-4B-g-2601"
+    )
+
+
+def test_unknown_model_name_is_passed_through_unchanged():
+    custom_name = "my-org/my-custom-model"
+    assert ScopeGuard.maybe_map_model(custom_name) == custom_name
+
+
+def test_model_mapping_contains_all_documented_aliases():
+    assert "scope-guard" in MODEL_MAPPING
+    assert "scope-guard-q" in MODEL_MAPPING
+    assert "scope-guard-g" in MODEL_MAPPING

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,48 @@
+"""Tests for the public import surface documented in the README.
+
+The READMEs advertise a small set of names that users can import directly.
+These tests lock that surface in so accidental renames are caught early.
+"""
+
+from __future__ import annotations
+
+
+def test_scope_guard_importable_from_scope_guard():
+    from orbitals.scope_guard import ScopeGuard
+
+    assert ScopeGuard is not None
+
+
+def test_async_scope_guard_importable_from_scope_guard():
+    from orbitals.scope_guard import AsyncScopeGuard
+
+    assert AsyncScopeGuard is not None
+
+
+def test_scope_class_importable_from_scope_guard():
+    from orbitals.scope_guard import ScopeClass
+
+    assert ScopeClass is not None
+
+
+def test_scope_guard_output_importable_from_scope_guard():
+    from orbitals.scope_guard import ScopeGuardOutput
+
+    assert ScopeGuardOutput is not None
+
+
+def test_ai_service_description_importable_from_types():
+    from orbitals.types import AIServiceDescription
+
+    assert AIServiceDescription is not None
+
+
+def test_scope_guard_package_all_is_exhaustive():
+    import orbitals.scope_guard as sg
+
+    assert set(sg.__all__) == {
+        "AsyncScopeGuard",
+        "ScopeClass",
+        "ScopeGuardOutput",
+        "ScopeGuard",
+    }

--- a/tests/test_scope_class.py
+++ b/tests/test_scope_class.py
@@ -1,0 +1,58 @@
+"""Tests for ScopeClass values documented in the README.
+
+From `README.scope-guard.md`:
+
+    print(ScopeClass.DIRECTLY_SUPPORTED.value)    # "Directly Supported"
+    print(ScopeClass.POTENTIALLY_SUPPORTED.value) # "Potentially Supported"
+    print(ScopeClass.OUT_OF_SCOPE.value)          # "Out of Scope"
+    print(ScopeClass.RESTRICTED.value)            # "Restricted"
+    print(ScopeClass.CHIT_CHAT.value)             # "Chit Chat"
+"""
+
+from __future__ import annotations
+
+from orbitals.scope_guard import ScopeClass
+
+
+def test_directly_supported_value():
+    assert ScopeClass.DIRECTLY_SUPPORTED.value == "Directly Supported"
+
+
+def test_potentially_supported_value():
+    assert ScopeClass.POTENTIALLY_SUPPORTED.value == "Potentially Supported"
+
+
+def test_out_of_scope_value():
+    assert ScopeClass.OUT_OF_SCOPE.value == "Out of Scope"
+
+
+def test_restricted_value():
+    assert ScopeClass.RESTRICTED.value == "Restricted"
+
+
+def test_chit_chat_value():
+    assert ScopeClass.CHIT_CHAT.value == "Chit Chat"
+
+
+def test_scope_class_has_exactly_five_members():
+    assert {m.value for m in ScopeClass} == {
+        "Directly Supported",
+        "Potentially Supported",
+        "Out of Scope",
+        "Restricted",
+        "Chit Chat",
+    }
+
+
+def test_scope_class_is_string_enum():
+    assert ScopeClass.RESTRICTED == "Restricted"
+
+
+def test_scope_class_comparison_by_enum_member():
+    cls = ScopeClass("Restricted")
+    assert cls == ScopeClass.RESTRICTED
+
+
+def test_scope_class_comparison_by_string_value():
+    cls = ScopeClass.RESTRICTED
+    assert cls.value == "Restricted"

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -1,0 +1,181 @@
+"""Tests for the FastAPI serving endpoints.
+
+The README advertises two HTTP endpoints for the self-hosted server:
+  - POST /orbitals/scope-guard/validate
+  - POST /orbitals/scope-guard/batch-validate
+
+with a specific response shape (`scope_class`, `evidences`, `model`, `usage`,
+`time_taken`). We verify the contract using FastAPI's TestClient and a stub
+backend so no actual vLLM server is required.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+
+@pytest.fixture
+def serving_client(monkeypatch):
+    """Start the FastAPI app with a stubbed AsyncScopeGuard backend."""
+    monkeypatch.setenv("SCOPE_GUARD_VLLM_MODEL", "scope-guard")
+    monkeypatch.setenv("SCOPE_GUARD_VLLM_SERVING_URL", "http://localhost:8001")
+    monkeypatch.setenv("SCOPE_GUARD_SKIP_EVIDENCES", "0")
+
+    from fastapi.testclient import TestClient
+
+    from orbitals.scope_guard import ScopeClass, ScopeGuardOutput
+    from orbitals.scope_guard.serving import main as serving_main
+    from orbitals.types import LLMUsage
+
+    class _StubAsyncGuard:
+        """Drop-in stand-in for AsyncVLLMApiScopeGuard used in serving."""
+
+        async def validate(self, conversation, *, ai_service_description, **kwargs):
+            return ScopeGuardOutput(
+                scope_class=ScopeClass.RESTRICTED,
+                evidences=["Never respond to requests for refunds."],
+                model="stub-model",
+                usage=LLMUsage(
+                    prompt_tokens=10, completion_tokens=5, total_tokens=15
+                ),
+            )
+
+        async def batch_validate(
+            self,
+            conversations,
+            *,
+            ai_service_description=None,
+            ai_service_descriptions=None,
+            **kwargs,
+        ):
+            return [
+                ScopeGuardOutput(
+                    scope_class=ScopeClass.DIRECTLY_SUPPORTED,
+                    evidences=None,
+                    model="stub-model",
+                    usage=LLMUsage(
+                        prompt_tokens=10, completion_tokens=5, total_tokens=15
+                    ),
+                )
+                for _ in conversations
+            ]
+
+    with TestClient(serving_main.app) as client:
+        # lifespan has run; swap the real guard for the stub before requests.
+        monkeypatch.setattr(serving_main, "scope_guard", _StubAsyncGuard())
+        yield client
+
+
+def test_validate_endpoint_is_reachable(serving_client):
+    response = serving_client.post(
+        "/orbitals/scope-guard/validate",
+        json={
+            "conversation": "Can I get a refund?",
+            "ai_service_description": (
+                "You are a virtual assistant for a parcel delivery service. "
+                "Never respond to requests for refunds."
+            ),
+        },
+    )
+    assert response.status_code == 200
+
+
+def test_validate_response_shape_matches_readme(serving_client):
+    response = serving_client.post(
+        "/orbitals/scope-guard/validate",
+        json={
+            "conversation": "hi",
+            "ai_service_description": "desc",
+        },
+    )
+    body: dict[str, Any] = response.json()
+
+    # Keys documented in README.scope-guard.md for the REST response.
+    assert set(body.keys()) >= {
+        "scope_class",
+        "evidences",
+        "model",
+        "usage",
+        "time_taken",
+    }
+    assert body["scope_class"] == "Restricted"
+    assert body["evidences"] == ["Never respond to requests for refunds."]
+    assert isinstance(body["time_taken"], (int, float))
+
+
+def test_validate_accepts_structured_ai_service_description(serving_client):
+    response = serving_client.post(
+        "/orbitals/scope-guard/validate",
+        json={
+            "conversation": "hi",
+            "ai_service_description": {
+                "identity_role": "Parcel delivery assistant",
+                "context": "Online logistics.",
+            },
+        },
+    )
+    assert response.status_code == 200
+
+
+def test_validate_accepts_multi_turn_conversation(serving_client):
+    response = serving_client.post(
+        "/orbitals/scope-guard/validate",
+        json={
+            "conversation": [
+                {"role": "user", "content": "I ordered a package"},
+                {"role": "assistant", "content": "How can I help?"},
+                {"role": "user", "content": "Can I refund?"},
+            ],
+            "ai_service_description": "desc",
+        },
+    )
+    assert response.status_code == 200
+
+
+def test_validate_rejects_missing_ai_service_description(serving_client):
+    response = serving_client.post(
+        "/orbitals/scope-guard/validate",
+        json={"conversation": "hi"},
+    )
+    assert response.status_code == 422
+
+
+def test_batch_validate_endpoint_is_reachable(serving_client):
+    response = serving_client.post(
+        "/orbitals/scope-guard/batch-validate",
+        json={
+            "conversations": ["q1", "q2"],
+            "ai_service_description": "desc",
+        },
+    )
+    assert response.status_code == 200
+
+
+def test_batch_validate_returns_list_matching_input_size(serving_client):
+    response = serving_client.post(
+        "/orbitals/scope-guard/batch-validate",
+        json={
+            "conversations": ["q1", "q2", "q3"],
+            "ai_service_description": "desc",
+        },
+    )
+    body = response.json()
+    assert isinstance(body, list)
+    assert len(body) == 3
+    assert all("scope_class" in item for item in body)
+
+
+def test_batch_validate_accepts_per_conversation_descriptions(serving_client):
+    response = serving_client.post(
+        "/orbitals/scope-guard/batch-validate",
+        json={
+            "conversations": ["q1", "q2"],
+            "ai_service_descriptions": ["d1", "d2"],
+        },
+    )
+    assert response.status_code == 200
+    assert len(response.json()) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -301,6 +301,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "blake3"
 version = "1.0.8"
 source = { registry = "https://pypi.org/simple" }
@@ -685,7 +694,7 @@ wheels = [
 
 [[package]]
 name = "compressed-tensors"
-version = "0.13.0"
+version = "0.15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "loguru" },
@@ -693,9 +702,9 @@ dependencies = [
     { name = "torch" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/65/88dd1c58fb9d0ded51b5c86471b937a1525f91fad2211a6f051dc1ea822d/compressed_tensors-0.13.0.tar.gz", hash = "sha256:23893824d3498ea3f1a829f14a8fa85f9a5e76a34c711a038b8d7c619ca9a67c", size = 200995, upload-time = "2025-12-16T16:03:55.397Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/1b/c3c4a98ec5f2727656336f07a0c35862195c310d8eb0b2fa5b4be6848680/compressed_tensors-0.15.0.1.tar.gz", hash = "sha256:a8e93054e8a5ec49c980b09ed36c4c1249b4a8ee167920a8e461c4da26e78d99", size = 229412, upload-time = "2026-04-10T14:23:54.708Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/b5/61ac2563c62490922b603c09113a083fd74af3630ec3931e769484d6dcb5/compressed_tensors-0.13.0-py3-none-any.whl", hash = "sha256:3518799c9baf034eb642efb551db6b0537b8713d45a64fe4def26f7f8d6cabec", size = 192620, upload-time = "2025-12-16T16:03:53.041Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/52/93833dc1610e017ac5b7dcd59b8304d8ef67d1114c2d124e728a2cbbea12/compressed_tensors-0.15.0.1-py3-none-any.whl", hash = "sha256:e1b1f322e82e475715e242bad46925a304ea8e5c98b5055a15b8eb22fb6bfea9", size = 194260, upload-time = "2026-04-10T14:23:53.098Z" },
 ]
 
 [[package]]
@@ -1141,6 +1150,14 @@ wheels = [
 ]
 
 [[package]]
+name = "flashinfer-cubin"
+version = "0.6.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/e8/826f9452bc5f76b94d7eb025f03dcaf1b51b9ed7790386c0285191e69be4/flashinfer_cubin-0.6.6-py3-none-any.whl", hash = "sha256:36508dfc792eb5ecfb15d2c140a7702812e1fa1ab0fb03929b2ed55e3e8191f3", size = 267661457, upload-time = "2026-03-11T01:36:36.538Z" },
+]
+
+[[package]]
 name = "flashinfer-python"
 version = "0.6.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1505,21 +1522,22 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "0.36.2"
+version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "requests" },
     { name = "tqdm" },
+    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/89/e7aa12d8a6b9259bed10671abb25ae6fa437c0f88a86ecbf59617bae7759/huggingface_hub-1.11.0.tar.gz", hash = "sha256:15fb3713c7f9cdff7b808a94fd91664f661ab142796bb48c9cd9493e8d166278", size = 761749, upload-time = "2026-04-16T13:07:39.73Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
+    { url = "https://files.pythonhosted.org/packages/37/02/4f3f8997d1ea7fe0146b343e5e14bd065fa87af790d07e5576d31b31cc18/huggingface_hub-1.11.0-py3-none-any.whl", hash = "sha256:42a6de0afbfeb5e022222d36398f029679db4eb4778801aafda32257ae9131ab", size = 645499, upload-time = "2026-04-16T13:07:37.716Z" },
 ]
 
 [[package]]
@@ -1632,6 +1650,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -2951,7 +2978,7 @@ wheels = [
 
 [[package]]
 name = "orbitals"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -2964,6 +2991,7 @@ dependencies = [
 all = [
     { name = "accelerate" },
     { name = "fastapi", extra = ["standard"] },
+    { name = "httpx" },
     { name = "nvidia-ml-py" },
     { name = "transformers" },
     { name = "uvicorn" },
@@ -2973,6 +3001,7 @@ all = [
 scope-guard-all = [
     { name = "accelerate" },
     { name = "fastapi", extra = ["standard"] },
+    { name = "httpx" },
     { name = "nvidia-ml-py" },
     { name = "transformers" },
     { name = "uvicorn" },
@@ -2986,6 +3015,7 @@ scope-guard-hf = [
 ]
 scope-guard-serve = [
     { name = "fastapi", extra = ["standard"] },
+    { name = "httpx" },
     { name = "nvidia-ml-py" },
     { name = "transformers" },
     { name = "uvicorn" },
@@ -3005,7 +3035,11 @@ serving = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "fastapi", extra = ["standard"] },
+    { name = "httpx" },
     { name = "ipykernel" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ty" },
 ]
 
@@ -3014,6 +3048,7 @@ requires-dist = [
     { name = "accelerate", marker = "extra == 'scope-guard-hf'", specifier = ">=1.11.0" },
     { name = "aiohttp" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'serving'", specifier = ">=0.119.1" },
+    { name = "httpx", marker = "extra == 'scope-guard-serve'" },
     { name = "nvidia-ml-py", marker = "extra == 'scope-guard-hf'" },
     { name = "nvidia-ml-py", marker = "extra == 'scope-guard-vllm'" },
     { name = "orbitals", extras = ["scope-guard-all"], marker = "extra == 'all'" },
@@ -3024,18 +3059,22 @@ requires-dist = [
     { name = "orbitals", extras = ["serving"], marker = "extra == 'scope-guard-serve'" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "requests" },
-    { name = "transformers", marker = "extra == 'scope-guard-hf'", specifier = ">=4.47.0,<5.0.0" },
-    { name = "transformers", marker = "extra == 'scope-guard-vllm'", specifier = ">=4.47.0,<5.0.0" },
+    { name = "transformers", marker = "extra == 'scope-guard-hf'", specifier = ">=5.5.0,<6.0.0" },
+    { name = "transformers", marker = "extra == 'scope-guard-vllm'", specifier = ">=5.5.0,<6.0.0" },
     { name = "typer", specifier = ">=0.12.3" },
     { name = "uvicorn", marker = "extra == 'serving'", specifier = ">=0.29.0" },
-    { name = "vllm", marker = "extra == 'scope-guard-vllm'", specifier = ">=0.11.0" },
+    { name = "vllm", marker = "extra == 'scope-guard-vllm'", specifier = ">=0.19.1" },
     { name = "xgrammar", marker = "extra == 'scope-guard-vllm'" },
 ]
 provides-extras = ["serving", "scope-guard-hf", "scope-guard-vllm", "scope-guard-serve", "scope-guard-all", "all"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "fastapi", extras = ["standard"], specifier = ">=0.119.1" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "ipykernel" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "ty", specifier = "==0.0.1a23" },
 ]
 
@@ -3223,6 +3262,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -3828,6 +3876,38 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -5123,23 +5203,22 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "4.57.6"
+version = "5.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
     { name = "huggingface-hub" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
-    { name = "requests" },
     { name = "safetensors" },
     { name = "tokenizers" },
     { name = "tqdm" },
+    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912, upload-time = "2026-01-16T10:38:39.284Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/1e/1e244ab2ab50a863e6b52cc55761910567fa532b69a6740f6e99c5fdbd98/transformers-5.5.4.tar.gz", hash = "sha256:2e67cadba81fc7608cc07c4dd54f524820bc3d95b1cabd0ef3db7733c4f8b82e", size = 8227649, upload-time = "2026-04-13T16:55:55.181Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
+    { url = "https://files.pythonhosted.org/packages/29/fb/162a66789c65e5afa3b051309240c26bf37fbc8fea285b4546ae747995a2/transformers-5.5.4-py3-none-any.whl", hash = "sha256:0bd6281b82966fe5a7a16f553ea517a9db1dee6284d7cb224dfd88fc0dd1c167", size = 10236696, upload-time = "2026-04-13T16:55:51.497Z" },
 ]
 
 [[package]]
@@ -5297,7 +5376,7 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.18.1"
+version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -5312,6 +5391,7 @@ dependencies = [
     { name = "einops" },
     { name = "fastapi", extra = ["standard"] },
     { name = "filelock" },
+    { name = "flashinfer-cubin" },
     { name = "flashinfer-python" },
     { name = "gguf" },
     { name = "ijson" },
@@ -5365,10 +5445,10 @@ dependencies = [
     { name = "watchfiles" },
     { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/67/fcf535827a07c0abce9cda362aef43c24b98e2dc661254e419cf22b5bc71/vllm-0.18.1.tar.gz", hash = "sha256:8d18eff1c4ed21eb8cf7a45a1d1b34752d5ec287e79186e451d5c2f797cacdb7", size = 30814301, upload-time = "2026-03-31T05:55:41.862Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/49/60a2a962ecbf780c8fbfd0d5548b208d654d5c4267df94d8d93883641431/vllm-0.19.1.tar.gz", hash = "sha256:9fb88ce6b50991eba41d183584f65f51d7f6015d86a42cdabf79c1c8bd5d66fa", size = 31105401, upload-time = "2026-04-18T05:50:15.143Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/5c/539cc73e98496031f53712cc3630cbf6642480e5d760fb4763068a4d4b7c/vllm-0.18.1-cp38-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:7e9e16639114760919ca86b74e8ac4be78e2593cd44ff387477e000a25ab5569", size = 385590570, upload-time = "2026-03-31T05:56:44.892Z" },
-    { url = "https://files.pythonhosted.org/packages/98/c8/dfc8a55242b5b9cf2ca0b212d443783dc934b7d7018a659bbec721ca8df4/vllm-0.18.1-cp38-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:33d6d81299dedd45dde43fef261fbad2d513ed80e7cf7e64fb5880e8cf8ea105", size = 433216393, upload-time = "2026-03-31T05:56:13.123Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4c/26c426103c58ac8d98435fe63c7758a2f289b5481a08be19e9c9fe29a4c2/vllm-0.19.1-cp38-abi3-manylinux_2_31_aarch64.whl", hash = "sha256:c8dde3c9af20f00a644e64a50ebe43948f2921bab3ffd5407d634c15836cb181", size = 385252556, upload-time = "2026-04-18T05:49:16.101Z" },
+    { url = "https://files.pythonhosted.org/packages/78/20/f41216b79c87372a9d03175f36fa1411ee61059ce8c557d2691722ea4aae/vllm-0.19.1-cp38-abi3-manylinux_2_31_x86_64.whl", hash = "sha256:71a87f46cafab4489c69a5c5c83b870d0235e5694d8222303d460576293dc719", size = 433132101, upload-time = "2026-04-18T05:49:54.202Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump lower bounds for `transformers` (`>=5.5.0,<6.0.0`) and `vllm` (`>=0.19.1`) in the `scope-guard-hf` and `scope-guard-vllm` extras to keep pace with upstream releases. `uv.lock` regenerated; notable resolved bumps: `transformers` 4.57.6 → 5.5.4, `vllm` 0.18.1 → 0.19.1, `huggingface-hub` 0.36.2 → 1.11.0.
- Add a unit test suite under `tests/` (75 tests, ~0.7s, no GPU required) anchored to the public surface documented in `README.md` and `README.scope-guard.md`. Covers the import surface, `ScopeClass` enum, conversation input formats, `AIServiceDescription`, shared batch-validation invariants, default-model alias resolution, the sync/async API backends (mocked), the FastAPI serving endpoints (via TestClient with a stubbed backend), and the Typer CLI.
- Add an end-to-end bash battery under `scripts/test-readme-examples/` that exercises every README code example against real models and a real FastAPI/vLLM server. Each script is self-contained and asserts on documented behaviour; `run-all.sh` shares a single served instance across the served scripts so the model only loads once. The hosted-API example is intentionally not scripted (the public endpoint is "coming soon").

## Test plan

- [x] `uv run pytest` (75 passed)
- [x] `bash -n` syntax check on every script in `scripts/test-readme-examples/`
- [x] On a CUDA host: `./scripts/test-readme-examples/run-all.sh` (full battery against real models)
- [x] Manual smoke test of the vLLM and HF backends with `transformers 5.5.x` / `vllm 0.19.x` to confirm no API breakage from the upstream major version bumps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to major `transformers`/`vllm` version bound increases and a regenerated lockfile that can introduce upstream runtime breakages; the rest is test and scripting additions.
> 
> **Overview**
> Bumps the `scope-guard-hf`/`scope-guard-vllm` extras to `transformers>=5.5.0,<6.0.0` and `vllm>=0.19.1` (with a regenerated `uv.lock`, including large transitive version shifts).
> 
> Adds a `pytest`/`pytest-asyncio`-based unit test suite and config in `pyproject.toml` to lock in the README-documented public API/CLI, input validation, model alias mapping, API backend request/response shapes (sync + async), and FastAPI serving endpoint contracts.
> 
> Introduces `scripts/test-readme-examples/` as an end-to-end bash battery that runs the README examples against real models and a real served instance (including a shared server runner and common helpers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ec693efac43be98ac5f2f66e5c94a058b01e12a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->