### PR TITLE
feat: make model parameter optional in scope guards with API backend

### DIFF
--- a/src/orbitals/scope_guard/guards/api.py
+++ b/src/orbitals/scope_guard/guards/api.py
@@ -15,13 +15,13 @@ from .base import AsyncScopeGuard, DefaultModel, ScopeGuard
 
 
 def _build_request_data(
-    model: str,
+    model: str | None,
     conversation: ScopeGuardInput,
     skip_evidences: bool,
     ai_service_description: str | AIServiceDescription,
 ) -> dict:
     return {
-        "model": model,
+        **({"model": model} if model is not None else {}),
         "conversation": ScopeGuardInputTypeAdapter.dump_python(conversation),
         "ai_service_description": ai_service_description.model_dump()
         if isinstance(ai_service_description, AIServiceDescription)
@@ -31,14 +31,14 @@ def _build_request_data(
 
 
 def _build_batch_request_data(
-    model: str,
+    model: str | None,
     conversations: list[ScopeGuardInput],
     skip_evidences: bool,
     ai_service_description: str | AIServiceDescription | None = None,
     ai_service_descriptions: list[str] | list[AIServiceDescription] | None = None,
 ) -> dict:
     return {
-        "model": model,
+        **({"model": model} if model is not None else {}),
         "conversations": [
             ScopeGuardInputTypeAdapter.dump_python(conversation)
             for conversation in conversations
@@ -90,14 +90,16 @@ class APIScopeGuard(ScopeGuard):
     def __init__(
         self,
         backend: Literal["api"] = "api",
-        model: DefaultModel | str = "scope-guard",
+        model: DefaultModel | str | None = None,
         api_url: str = "http://localhost:8000",
         api_key: str | None = None,
         skip_evidences: bool = False,
         custom_headers: dict[str, str] | None = None,
     ):
         super().__init__(backend)
-        self.default_model = self.maybe_map_model(model)
+        self.default_model = (
+            self.maybe_map_model(model) if model is not None else None
+        )
         self.api_url = api_url
         self.api_key = _maybe_get_api_key(api_key, custom_headers)
         self.skip_evidences = skip_evidences
@@ -178,14 +180,16 @@ class AsyncAPIScopeGuard(AsyncScopeGuard):
     def __init__(
         self,
         backend: Literal["api", "async-api"] = "api",
-        model: DefaultModel | str = "scope-guard",
+        model: DefaultModel | str | None = None,
         api_url: str = "http://localhost:8000",
         api_key: str | None = None,
         skip_evidences: bool = False,
         custom_headers: dict[str, str] | None = None,
     ):
         super().__init__(backend)
-        self.default_model = self.maybe_map_model(model)
+        self.default_model = (
+            self.maybe_map_model(model) if model is not None else None
+        )
         self.api_url = api_url
         self.api_key = _maybe_get_api_key(api_key, custom_headers)
         self.skip_evidences = skip_evidences

--- a/src/orbitals/scope_guard/guards/base.py
+++ b/src/orbitals/scope_guard/guards/base.py
@@ -161,7 +161,7 @@ class ScopeGuard(BaseScopeGuard):
     def __new__(
         cls,
         backend: Literal["api"],
-        model: DefaultModel | str = "scope-guard",
+        model: DefaultModel | str | None = None,
         api_url: str = "http://localhost:8000",
         api_key: str | None = None,
         skip_evidences: bool = False,
@@ -252,7 +252,7 @@ class AsyncScopeGuard(BaseScopeGuard):
     def __new__(
         cls,
         backend: Literal["api"],
-        model: DefaultModel | str = "scope-guard",
+        model: DefaultModel | str | None = None,
         api_url: str = "http://localhost:8000",
         api_key: str | None = None,
         skip_evidences: bool = False,


### PR DESCRIPTION
## Summary
- Make the `model` parameter optional (default `None`) on `APIScopeGuard` / `AsyncAPIScopeGuard` and their `ScopeGuard` / `AsyncScopeGuard` entry points.
- When `model` is not provided, omit the `model` key from the request payload instead of sending the previous `"scope-guard"` default — lets the server apply its own default.
- Skip `maybe_map_model` mapping when no model is supplied.

## Test plan
- [ ] Instantiate `ScopeGuard(backend="api")` without passing `model` and confirm the outgoing request has no `model` field.
- [ ] Instantiate with an explicit `model=` and confirm the value is sent through as before.
- [ ] Same checks for the async variant and for batch requests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default behavior for the API/async-API backends by no longer sending a default model name, which can alter server-side model selection and validation results for existing callers.
> 
> **Overview**
> **API-backed scope guards now treat `model` as optional.** `APIScopeGuard`/`AsyncAPIScopeGuard` (and the `ScopeGuard`/`AsyncScopeGuard` overload entry points for `backend="api"`) default `model` to `None` instead of `"scope-guard"`.
> 
> When no model is provided, request payload builders omit the `model` field entirely (single and batch), and `maybe_map_model` is skipped unless a model is explicitly supplied—allowing the server to apply its own default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f81d16f9e0793fd62882af445522e335038f566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->