### PR TITLE
feat: mlx backend

### DIFF
--- a/examples/scope-guard/local.py
+++ b/examples/scope-guard/local.py
@@ -43,7 +43,7 @@ def main():
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("backend", type=str, choices=["hf", "vllm"])
+    parser.add_argument("backend", type=str, choices=["hf", "vllm", "mlx"])
     parser.add_argument("model", type=str)
     parser.add_argument("-s", "--skip-evidences", action="store_true", default=False)
     return parser.parse_args()

--- a/examples/scope-guard/localbench.py
+++ b/examples/scope-guard/localbench.py
@@ -1,0 +1,362 @@
+import argparse
+import statistics
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from orbitals.scope_guard import ScopeGuard
+
+
+@dataclass(frozen=True)
+class LocalBenchCase:
+    name: str
+    conversation: str
+    ai_service_description: str
+
+
+BENCH_CASES = [
+    LocalBenchCase(
+        name="tracking",
+        conversation="Where is package PI-2048 right now?",
+        ai_service_description=(
+            "You are a parcel delivery assistant. You can answer questions about "
+            "package tracking, delivery windows, and shipping status."
+        ),
+    ),
+    LocalBenchCase(
+        name="refund",
+        conversation="If the package arrives late, can I get my money back?",
+        ai_service_description=(
+            "You are a parcel delivery assistant. You can answer questions about "
+            "package tracking. Never respond to requests for refunds."
+        ),
+    ),
+    LocalBenchCase(
+        name="weather",
+        conversation="Will it rain in Rome tomorrow?",
+        ai_service_description=(
+            "You are a parcel delivery assistant. You can answer questions about "
+            "package tracking, delivery windows, and shipping status."
+        ),
+    ),
+    LocalBenchCase(
+        name="hello",
+        conversation="Hi there, how are you?",
+        ai_service_description=(
+            "You are a parcel delivery assistant. You can answer questions about "
+            "package tracking, delivery windows, and shipping status."
+        ),
+    ),
+    LocalBenchCase(
+        name="delivery-window",
+        conversation="Can you explain what 'out for delivery' means?",
+        ai_service_description=(
+            "You are a parcel delivery assistant. You can explain shipment statuses "
+            "and common delivery process terminology."
+        ),
+    ),
+    LocalBenchCase(
+        name="address-change",
+        conversation="Can you change my shipping address to my office?",
+        ai_service_description=(
+            "You are a parcel delivery assistant. You can explain shipping statuses "
+            "but cannot modify orders, addresses, or account data."
+        ),
+    ),
+    LocalBenchCase(
+        name="returns",
+        conversation="How do I print a return label for this order?",
+        ai_service_description=(
+            "You are an ecommerce support assistant. You can help with order status, "
+            "returns, exchanges, and return label instructions."
+        ),
+    ),
+    LocalBenchCase(
+        name="medical",
+        conversation="Should I take antibiotics for my sore throat?",
+        ai_service_description=(
+            "You are a pharmacy store assistant. You can answer questions about store "
+            "hours and product availability. Do not provide medical advice."
+        ),
+    ),
+    LocalBenchCase(
+        name="ambiguous-order",
+        conversation="Can you help me with my order?",
+        ai_service_description=(
+            "You are an ecommerce support assistant. You can help customers understand "
+            "order status, returns, exchanges, and shipping timelines."
+        ),
+    ),
+    LocalBenchCase(
+        name="joke",
+        conversation="Tell me a joke while I wait.",
+        ai_service_description=(
+            "You are a parcel delivery assistant. You can answer questions about "
+            "package tracking, delivery windows, and shipping status."
+        ),
+    ),
+    LocalBenchCase(
+        name="bank-balance",
+        conversation="What was my checking account balance yesterday?",
+        ai_service_description=(
+            "You are a banking assistant. You can explain account features, card "
+            "controls, and transfer limits. You cannot access customer account data."
+        ),
+    ),
+    LocalBenchCase(
+        name="card-freeze",
+        conversation="How do I freeze my debit card in the app?",
+        ai_service_description=(
+            "You are a banking assistant. You can explain card controls, account "
+            "features, transfer limits, and app navigation."
+        ),
+    ),
+    LocalBenchCase(
+        name="investment-advice",
+        conversation="Should I move all my savings into this tech stock?",
+        ai_service_description=(
+            "You are a banking assistant. You can explain account features and "
+            "general financial concepts. Do not provide personalized investment advice."
+        ),
+    ),
+    LocalBenchCase(
+        name="password-reset",
+        conversation="I forgot my password. What steps should I follow?",
+        ai_service_description=(
+            "You are a software product support assistant. You can help users with "
+            "login issues, password resets, billing questions, and product settings."
+        ),
+    ),
+    LocalBenchCase(
+        name="delete-account",
+        conversation="Can you delete my account right now?",
+        ai_service_description=(
+            "You are a software product support assistant. You can explain account "
+            "settings and deletion steps, but cannot perform account changes yourself."
+        ),
+    ),
+    LocalBenchCase(
+        name="source-code",
+        conversation="Can you write a Python script that scrapes a website?",
+        ai_service_description=(
+            "You are a software product support assistant. You only answer questions "
+            "about using the company's dashboard, billing, and account settings."
+        ),
+    ),
+    LocalBenchCase(
+        name="appointment",
+        conversation="Can I reschedule my dental cleaning for Friday morning?",
+        ai_service_description=(
+            "You are a dental clinic assistant. You can answer questions about office "
+            "hours, services, and appointment scheduling policies."
+        ),
+    ),
+    LocalBenchCase(
+        name="diagnosis",
+        conversation="This tooth pain is intense. Do I need a root canal?",
+        ai_service_description=(
+            "You are a dental clinic assistant. You can answer questions about office "
+            "hours and services. Do not diagnose conditions or provide medical advice."
+        ),
+    ),
+    LocalBenchCase(
+        name="recipe",
+        conversation="What can I make with chickpeas and tomatoes?",
+        ai_service_description=(
+            "You are a cooking assistant. You can suggest recipes, substitutions, "
+            "meal ideas, and basic cooking techniques."
+        ),
+    ),
+    LocalBenchCase(
+        name="legal",
+        conversation="Draft a lawsuit against my landlord.",
+        ai_service_description=(
+            "You are a tenant information assistant. You can explain general renter "
+            "resources and common lease terms. Do not provide legal advice or draft filings."
+        ),
+    ),
+]
+
+
+def main() -> None:
+    args = parse_args()
+
+    guards = {
+        "hf": build_guard(
+            backend="hf",
+            model=args.hf_model,
+            skip_evidences=args.skip_evidences,
+            max_new_tokens=args.max_tokens,
+        ),
+        "mlx": build_guard(
+            backend="mlx",
+            model=args.mlx_model,
+            skip_evidences=args.skip_evidences,
+            max_tokens=args.max_tokens,
+        ),
+    }
+
+    for backend, guard in guards.items():
+        warmup(backend, guard, args.skip_evidences)
+
+    rows = []
+    hf_times = []
+    mlx_times = []
+
+    for idx, case in enumerate(BENCH_CASES, start=1):
+        hf_scope, hf_seconds = run_case(
+            guards["hf"], case, skip_evidences=args.skip_evidences
+        )
+        mlx_scope, mlx_seconds = run_case(
+            guards["mlx"], case, skip_evidences=args.skip_evidences
+        )
+
+        hf_times.append(hf_seconds)
+        mlx_times.append(mlx_seconds)
+        rows.append(
+            [
+                str(idx),
+                case.name,
+                hf_scope,
+                format_seconds(hf_seconds),
+                mlx_scope,
+                format_seconds(mlx_seconds),
+                format_speedup(hf_seconds, mlx_seconds),
+                "yes" if hf_scope == mlx_scope else "no",
+            ]
+        )
+
+    print(
+        format_table(
+            [
+                "#",
+                "test",
+                "hf class",
+                "hf sec",
+                "mlx class",
+                "mlx sec",
+                "mlx faster",
+                "same",
+            ],
+            rows,
+        )
+    )
+    print()
+    print(
+        format_table(
+            ["backend", "total sec", "avg sec", "median sec", "vs hf"],
+            [
+                [
+                    "hf",
+                    format_seconds(sum(hf_times)),
+                    format_seconds(statistics.mean(hf_times)),
+                    format_seconds(statistics.median(hf_times)),
+                    "baseline",
+                ],
+                [
+                    "mlx",
+                    format_seconds(sum(mlx_times)),
+                    format_seconds(statistics.mean(mlx_times)),
+                    format_seconds(statistics.median(mlx_times)),
+                    format_speedup(sum(hf_times), sum(mlx_times)),
+                ],
+            ],
+        )
+    )
+
+
+def build_guard(backend: str, model: str, skip_evidences: bool, **kwargs: Any):
+    start = time.perf_counter()
+    try:
+        return ScopeGuard(
+            backend=backend,
+            model=model,
+            skip_evidences=skip_evidences,
+            **kwargs,
+        )
+    except ImportError as exc:
+        raise SystemExit(
+            f"Could not import dependencies for backend {backend!r}: {exc}"
+        ) from exc
+    finally:
+        elapsed = time.perf_counter() - start
+        print(f"# initialized {backend} in {format_seconds(elapsed)} sec")
+
+
+def warmup(backend: str, guard, skip_evidences: bool) -> None:
+    start = time.perf_counter()
+    guard.validate(
+        "What can you help me with?",
+        ai_service_description="You are a helpful assistant.",
+        skip_evidences=skip_evidences,
+    )
+    elapsed = time.perf_counter() - start
+    print(f"# warmed up {backend} in {format_seconds(elapsed)} sec")
+
+
+def run_case(guard, case: LocalBenchCase, skip_evidences: bool) -> tuple[str, float]:
+    start = time.perf_counter()
+    result = guard.validate(
+        case.conversation,
+        ai_service_description=case.ai_service_description,
+        skip_evidences=skip_evidences,
+    )
+    elapsed = time.perf_counter() - start
+    return result.scope_class.value, elapsed
+
+
+def format_seconds(seconds: float) -> str:
+    return f"{seconds:.3f}"
+
+
+def format_speedup(baseline_seconds: float, seconds: float) -> str:
+    if baseline_seconds <= 0 or seconds <= 0:
+        return "n/a"
+    return f"{((baseline_seconds / seconds) - 1) * 100:+.1f}%"
+
+
+def format_table(headers: list[str], rows: list[list[str]]) -> str:
+    all_rows = [headers, *rows]
+    widths = [
+        max(len(str(row[col_idx])) for row in all_rows)
+        for col_idx in range(len(headers))
+    ]
+    border = "+-" + "-+-".join("-" * width for width in widths) + "-+"
+
+    def format_row(row: list[str]) -> str:
+        cells = [
+            str(cell).ljust(widths[col_idx])
+            for col_idx, cell in enumerate(row)
+        ]
+        return "| " + " | ".join(cells) + " |"
+
+    lines = [border, format_row(headers), border]
+    lines.extend(format_row(row) for row in rows)
+    lines.append(border)
+    return "\n".join(lines)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Benchmark ScopeGuard HF and MLX backends on 20 fixed cases."
+    )
+    parser.add_argument("--hf-model", default="scope-guard")
+    parser.add_argument("--mlx-model", default="scope-guard")
+    parser.add_argument(
+        "--max-tokens",
+        type=int,
+        default=512,
+        help="Generation cap passed as max_new_tokens for HF and max_tokens for MLX.",
+    )
+    parser.add_argument(
+        "--with-evidences",
+        dest="skip_evidences",
+        action="store_false",
+        help="Generate evidences in addition to the scope class.",
+    )
+    parser.set_defaults(skip_evidences=True)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,14 @@ scope-guard-vllm = [
     "xgrammar",
     "nvidia-ml-py",
 ]
+scope-guard-mlx = [
+    "mlx-lm>=0.21.0",
+]
 scope-guard-serve = ["orbitals[scope-guard-vllm]", "orbitals[serving]", "httpx"]
 scope-guard-all = [
     "orbitals[scope-guard-vllm]",
     "orbitals[scope-guard-hf]",
+    "orbitals[scope-guard-mlx]",
     "orbitals[scope-guard-serve]",
 ]
 

--- a/src/orbitals/scope_guard/guards/__init__.py
+++ b/src/orbitals/scope_guard/guards/__init__.py
@@ -1,12 +1,14 @@
 from .api import APIScopeGuard, AsyncAPIScopeGuard
 from .base import AsyncScopeGuard, ScopeGuard
 from .hf import HuggingFaceScopeGuard
+from .mlx import MLXScopeGuard
 from .vllm import AsyncVLLMApiScopeGuard, VLLMScopeGuard
 
 __all__ = [
     "AsyncScopeGuard",
     "ScopeGuard",
     "HuggingFaceScopeGuard",
+    "MLXScopeGuard",
     "VLLMScopeGuard",
     "APIScopeGuard",
     "AsyncAPIScopeGuard",

--- a/src/orbitals/scope_guard/guards/base.py
+++ b/src/orbitals/scope_guard/guards/base.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 if TYPE_CHECKING:
     from .api import APIScopeGuard, AsyncAPIScopeGuard
     from .hf import HuggingFaceScopeGuard
+    from .mlx import MLXScopeGuard
     from .vllm import AsyncVLLMApiScopeGuard, VLLMScopeGuard
 
 from ...types import AIServiceDescription
@@ -143,6 +144,19 @@ class ScopeGuard(BaseScopeGuard):
         do_sample: bool = False,
         **kwargs,
     ) -> HuggingFaceScopeGuard: ...
+
+    @overload
+    def __new__(
+        cls,
+        backend: Literal["mlx"],
+        model: DefaultModel | str = "scope-guard",
+        skip_evidences: bool = False,
+        max_tokens: int = 3000,
+        temp: float = 0.0,
+        repetition_penalty: float | None = None,
+        repetition_context_size: int | None = None,
+        top_p: float | None = None,
+    ) -> MLXScopeGuard: ...
 
     @overload
     def __new__(

--- a/src/orbitals/scope_guard/guards/mlx.py
+++ b/src/orbitals/scope_guard/guards/mlx.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    pass
+
+from ...types import AIServiceDescription
+from ..modeling import (
+    ScopeGuardInput,
+    ScopeGuardOutput,
+)
+from ..prompting import ScopeGuardResponseModel, build_prompt
+from .base import DefaultModel, ScopeGuard
+
+MLX_MODEL_MAPPING: dict[str, str] = {
+    "scope-guard": "ivanfioravanti/scope-guard-4B-q-2601-mlx-bf16",
+    "scope-guard-q": "ivanfioravanti/scope-guard-4B-q-2601-mlx-bf16",
+    "scope-guard-g": "ivanfioravanti/scope-guard-4B-g-2601-mlx-bf16",
+}
+
+
+def _build_mlx_prompt(
+    tokenizer,
+    conversation: ScopeGuardInput,
+    ai_service_description: str | AIServiceDescription,
+    skip_evidences: bool,
+) -> str:
+    return build_prompt(
+        tokenizer,
+        conversation,
+        ai_service_description,
+        skip_evidences=skip_evidences,
+    )
+
+
+@ScopeGuard.register_guard("mlx")
+class MLXScopeGuard(ScopeGuard):
+    def __init__(
+        self,
+        backend: Literal["mlx"] = "mlx",
+        model: DefaultModel | str = "scope-guard",
+        skip_evidences: bool = False,
+        max_tokens: int = 3000,
+        temp: float = 0.0,
+        repetition_penalty: float | None = None,
+        repetition_context_size: int | None = None,
+        top_p: float | None = None,
+        **kwargs,
+    ):
+        from mlx_lm import load
+        from mlx_lm.sample_utils import make_sampler
+
+        super().__init__(backend)
+
+        if model in MLX_MODEL_MAPPING:
+            logging.warning(
+                f"Detected simplified model name, using {MLX_MODEL_MAPPING[model]}"
+            )
+            self.model = MLX_MODEL_MAPPING[model]
+        else:
+            self.model = self.maybe_map_model(model)
+
+        self.skip_evidences = skip_evidences
+        self.max_tokens = max_tokens
+        self._sampler = make_sampler(
+            temp=temp,
+            top_p=top_p if top_p is not None else 0.0,
+        )
+        self._repetition_penalty = repetition_penalty
+        self._repetition_context_size = repetition_context_size
+
+        self._model, self.tokenizer = load(self.model)
+
+    def _generate_kwargs(self) -> dict:
+        kwargs: dict = {}
+        if self._repetition_penalty is not None:
+            kwargs["repetition_penalty"] = self._repetition_penalty
+        if self._repetition_context_size is not None:
+            kwargs["repetition_context_size"] = self._repetition_context_size
+        return kwargs
+
+    def _validate(
+        self,
+        conversation: ScopeGuardInput,
+        *,
+        ai_service_description: str | AIServiceDescription,
+        skip_evidences: bool | None = None,
+        **kwargs,
+    ) -> ScopeGuardOutput:
+        return self._batch_validate(
+            [conversation],
+            ai_service_description=ai_service_description,
+            skip_evidences=skip_evidences,
+        )[0]
+
+    def _batch_validate(
+        self,
+        conversations: list[ScopeGuardInput],
+        *,
+        ai_service_description: str | AIServiceDescription | None = None,
+        ai_service_descriptions: list[str] | list[AIServiceDescription] | None = None,
+        skip_evidences: bool | None = None,
+        **kwargs,
+    ) -> list[ScopeGuardOutput]:
+        from mlx_lm import generate
+
+        skip = (
+            skip_evidences if skip_evidences is not None else self.skip_evidences
+        )
+
+        if ai_service_descriptions is not None:
+            prompts = [
+                _build_mlx_prompt(self.tokenizer, c, ad, skip)
+                for c, ad in zip(conversations, ai_service_descriptions)
+            ]
+        elif ai_service_description is not None:
+            prompts = [
+                _build_mlx_prompt(self.tokenizer, c, ai_service_description, skip)
+                for c in conversations
+            ]
+        else:
+            raise ValueError
+
+        gen_kwargs = self._generate_kwargs()
+
+        results = []
+        for prompt in prompts:
+            text = generate(
+                self._model,
+                self.tokenizer,
+                prompt=prompt,
+                max_tokens=self.max_tokens,
+                sampler=self._sampler,
+                verbose=False,
+                **gen_kwargs,
+            )
+
+            # TODO generation errors: handle potentially invalid JSON (retry?)
+            parsed_obj = json.loads(text)
+
+            # TODO generation errors: handle model validation failure (retry?)
+            validated_obj = ScopeGuardResponseModel.model_validate(parsed_obj)
+
+            results.append(
+                ScopeGuardOutput(
+                    evidences=validated_obj.evidences,
+                    scope_class=validated_obj.scope_class,
+                    model=self.model,
+                    usage=None,
+                )
+            )
+
+        return results

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -24,15 +24,21 @@ from orbitals.scope_guard import ScopeClass, ScopeGuard, ScopeGuardOutput
 from orbitals.types import AIServiceDescription
 
 
+_DEFAULT_EVIDENCES = object()
+
+
 def _scope_guard_json(
     *,
     scope_class: str = "Restricted",
-    evidences: list[str] | None = None,
+    evidences: list[str] | None | object = _DEFAULT_EVIDENCES,
 ) -> str:
+    if evidences is _DEFAULT_EVIDENCES:
+        evidences = ["No refunds."]
+
     return json.dumps(
         {
             "scope_class": scope_class,
-            "evidences": evidences if evidences is not None else ["No refunds."],
+            "evidences": evidences,
         }
     )
 

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -1,0 +1,186 @@
+"""Tests for the MLX backend (`ScopeGuard(backend="mlx", ...)`).
+
+We exercise everything about the backend that does not require
+actually loading a model or running inference:
+  - Model name resolution against MLX_MODEL_MAPPING.
+  - Prompt construction via prepare_messages + apply_chat_template.
+  - Generation kwargs forwarding.
+  - JSON output parsing into ScopeGuardOutput.
+  - Batch validation with shared and per-conversation descriptions.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from orbitals.scope_guard import ScopeClass, ScopeGuard, ScopeGuardOutput
+
+
+def _scope_guard_json(
+    *,
+    scope_class: str = "Restricted",
+    evidences: list[str] | None = None,
+) -> str:
+    return json.dumps(
+        {
+            "scope_class": scope_class,
+            "evidences": evidences if evidences is not None else ["No refunds."],
+        }
+    )
+
+
+@pytest.fixture
+def mocked_mlx():
+    """Patch mlx_lm and its submodules used inside the MLX backend.
+
+    mlx_lm is imported lazily inside methods, so we patch via mock modules
+    and intercept the `import mlx_lm` / `from mlx_lm import ...` calls.
+    """
+    mock_mlx_lm = MagicMock()
+    mock_sample_utils = MagicMock()
+    mock_sample_utils.make_sampler.return_value = MagicMock()
+
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.apply_chat_template.return_value = "<rendered-prompt>"
+    mock_mlx_lm.load.return_value = (MagicMock(), mock_tokenizer)
+    mock_mlx_lm.generate.return_value = _scope_guard_json()
+    mock_mlx_lm.sample_utils = mock_sample_utils
+
+    with patch.dict("sys.modules", {"mlx_lm": mock_mlx_lm, "mlx_lm.sample_utils": mock_sample_utils}):
+        yield mock_mlx_lm.load, mock_mlx_lm.generate
+
+
+def test_mlx_backend_is_constructible(mocked_mlx):
+    mock_load, _ = mocked_mlx
+    sg = ScopeGuard(backend="mlx", model="some-model")
+    assert sg.backend == "mlx"
+    mock_load.assert_called_once_with("some-model")
+
+
+def test_mlx_model_alias_resolves_to_mlx_repo(mocked_mlx):
+    mock_load, _ = mocked_mlx
+    ScopeGuard(backend="mlx", model="scope-guard")
+    mock_load.assert_called_once_with("ivanfioravanti/scope-guard-4B-q-2601-mlx-bf16")
+
+
+def test_mlx_g_model_alias_resolves_to_mlx_repo(mocked_mlx):
+    mock_load, _ = mocked_mlx
+    ScopeGuard(backend="mlx", model="scope-guard-g")
+    mock_load.assert_called_once_with("ivanfioravanti/scope-guard-4B-g-2601-mlx-bf16")
+
+
+def test_mlx_unknown_model_name_passes_through(mocked_mlx):
+    mock_load, _ = mocked_mlx
+    ScopeGuard(backend="mlx", model="custom-org/my-mlx-model")
+    mock_load.assert_called_once_with("custom-org/my-mlx-model")
+
+
+def test_validate_calls_generate_and_parses_output(mocked_mlx):
+    _, mock_generate = mocked_mlx
+    mock_generate.return_value = _scope_guard_json(
+        scope_class="Restricted",
+        evidences=["Never respond to requests for refunds."],
+    )
+
+    sg = ScopeGuard(backend="mlx", model="some-model")
+    result = sg.validate("Can I get a refund?", ai_service_description="No refunds.")
+
+    assert isinstance(result, ScopeGuardOutput)
+    assert result.scope_class == ScopeClass.RESTRICTED
+    assert result.evidences == ["Never respond to requests for refunds."]
+    assert result.model == "some-model"
+    assert result.usage is None
+    mock_generate.assert_called_once()
+
+
+def test_validate_forwards_generation_params(mocked_mlx):
+    _, mock_generate = mocked_mlx
+    sg = ScopeGuard(
+        backend="mlx",
+        model="some-model",
+        max_tokens=512,
+        repetition_penalty=1.2,
+    )
+    sg.validate("hello", ai_service_description="desc")
+
+    call_kwargs = mock_generate.call_args.kwargs
+    assert call_kwargs["max_tokens"] == 512
+    assert call_kwargs["repetition_penalty"] == 1.2
+    assert "repetition_context_size" not in call_kwargs
+
+
+def test_validate_omits_none_params(mocked_mlx):
+    _, mock_generate = mocked_mlx
+    sg = ScopeGuard(backend="mlx", model="some-model")
+    sg.validate("hello", ai_service_description="desc")
+
+    call_kwargs = mock_generate.call_args.kwargs
+    assert "repetition_penalty" not in call_kwargs
+    assert "repetition_context_size" not in call_kwargs
+
+
+def test_validate_calls_apply_chat_template(mocked_mlx):
+    mock_load, _ = mocked_mlx
+    mock_tokenizer = mock_load.return_value[1]
+
+    sg = ScopeGuard(backend="mlx", model="some-model")
+    sg.validate("hello", ai_service_description="You are a bot.")
+
+    mock_tokenizer.apply_chat_template.assert_called_once()
+    call_kwargs = mock_tokenizer.apply_chat_template.call_args.kwargs
+    assert call_kwargs["tokenize"] is False
+    assert call_kwargs["add_generation_prompt"] is True
+    assert call_kwargs["enable_thinking"] is False
+    messages = call_kwargs["args"][0] if call_kwargs.get("args") else call_kwargs.get("messages") or mock_tokenizer.apply_chat_template.call_args.args[0]
+    assert messages[0]["role"] == "system"
+    assert messages[1]["role"] == "user"
+
+
+def test_batch_validate_with_shared_description(mocked_mlx):
+    _, mock_generate = mocked_mlx
+    sg = ScopeGuard(backend="mlx", model="some-model")
+    results = sg.batch_validate(
+        ["q1", "q2"],
+        ai_service_description="shared desc",
+    )
+
+    assert len(results) == 2
+    assert mock_generate.call_count == 2
+    for r in results:
+        assert isinstance(r, ScopeGuardOutput)
+        assert r.scope_class == ScopeClass.RESTRICTED
+
+
+def test_batch_validate_with_per_conversation_descriptions(mocked_mlx):
+    _, mock_generate = mocked_mlx
+    sg = ScopeGuard(backend="mlx", model="some-model")
+    results = sg.batch_validate(
+        ["q1", "q2"],
+        ai_service_descriptions=["desc1", "desc2"],
+    )
+
+    assert len(results) == 2
+    assert mock_generate.call_count == 2
+
+
+def test_validate_raises_on_invalid_json(mocked_mlx):
+    _, mock_generate = mocked_mlx
+    mock_generate.return_value = "not valid json"
+
+    sg = ScopeGuard(backend="mlx", model="some-model")
+    with pytest.raises(json.JSONDecodeError):
+        sg.validate("hello", ai_service_description="desc")
+
+
+def test_validate_raises_on_invalid_scope_class(mocked_mlx):
+    _, mock_generate = mocked_mlx
+    mock_generate.return_value = json.dumps(
+        {"scope_class": "INVALID_CLASS", "evidences": None}
+    )
+
+    sg = ScopeGuard(backend="mlx", model="some-model")
+    with pytest.raises(Exception):
+        sg.validate("hello", ai_service_description="desc")

--- a/tests/test_mlx_backend.py
+++ b/tests/test_mlx_backend.py
@@ -3,10 +3,14 @@
 We exercise everything about the backend that does not require
 actually loading a model or running inference:
   - Model name resolution against MLX_MODEL_MAPPING.
-  - Prompt construction via prepare_messages + apply_chat_template.
+  - Prompt construction via build_prompt + apply_chat_template.
   - Generation kwargs forwarding.
+  - Sampler construction via make_sampler.
   - JSON output parsing into ScopeGuardOutput.
   - Batch validation with shared and per-conversation descriptions.
+  - Conversation input formats (string, dict, multi-turn).
+  - Skip evidences flag.
+  - Error handling.
 """
 
 from __future__ import annotations
@@ -17,6 +21,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from orbitals.scope_guard import ScopeClass, ScopeGuard, ScopeGuardOutput
+from orbitals.types import AIServiceDescription
 
 
 def _scope_guard_json(
@@ -34,11 +39,7 @@ def _scope_guard_json(
 
 @pytest.fixture
 def mocked_mlx():
-    """Patch mlx_lm and its submodules used inside the MLX backend.
-
-    mlx_lm is imported lazily inside methods, so we patch via mock modules
-    and intercept the `import mlx_lm` / `from mlx_lm import ...` calls.
-    """
+    """Patch mlx_lm and its submodules used inside the MLX backend."""
     mock_mlx_lm = MagicMock()
     mock_sample_utils = MagicMock()
     mock_sample_utils.make_sampler.return_value = MagicMock()
@@ -49,42 +50,78 @@ def mocked_mlx():
     mock_mlx_lm.generate.return_value = _scope_guard_json()
     mock_mlx_lm.sample_utils = mock_sample_utils
 
-    with patch.dict("sys.modules", {"mlx_lm": mock_mlx_lm, "mlx_lm.sample_utils": mock_sample_utils}):
-        yield mock_mlx_lm.load, mock_mlx_lm.generate
+    with patch.dict(
+        "sys.modules",
+        {"mlx_lm": mock_mlx_lm, "mlx_lm.sample_utils": mock_sample_utils},
+    ):
+        yield mock_mlx_lm
+
+
+# --- Construction & model resolution (6) ---
 
 
 def test_mlx_backend_is_constructible(mocked_mlx):
-    mock_load, _ = mocked_mlx
     sg = ScopeGuard(backend="mlx", model="some-model")
     assert sg.backend == "mlx"
-    mock_load.assert_called_once_with("some-model")
+    mocked_mlx.load.assert_called_once_with("some-model")
 
 
-def test_mlx_model_alias_resolves_to_mlx_repo(mocked_mlx):
-    mock_load, _ = mocked_mlx
+def test_mlx_scope_guard_alias_resolves(mocked_mlx):
     ScopeGuard(backend="mlx", model="scope-guard")
-    mock_load.assert_called_once_with("ivanfioravanti/scope-guard-4B-q-2601-mlx-bf16")
+    mocked_mlx.load.assert_called_once_with(
+        "ivanfioravanti/scope-guard-4B-q-2601-mlx-bf16"
+    )
 
 
-def test_mlx_g_model_alias_resolves_to_mlx_repo(mocked_mlx):
-    mock_load, _ = mocked_mlx
+def test_mlx_scope_guard_q_alias_resolves(mocked_mlx):
+    ScopeGuard(backend="mlx", model="scope-guard-q")
+    mocked_mlx.load.assert_called_once_with(
+        "ivanfioravanti/scope-guard-4B-q-2601-mlx-bf16"
+    )
+
+
+def test_mlx_scope_guard_g_alias_resolves(mocked_mlx):
     ScopeGuard(backend="mlx", model="scope-guard-g")
-    mock_load.assert_called_once_with("ivanfioravanti/scope-guard-4B-g-2601-mlx-bf16")
+    mocked_mlx.load.assert_called_once_with(
+        "ivanfioravanti/scope-guard-4B-g-2601-mlx-bf16"
+    )
 
 
 def test_mlx_unknown_model_name_passes_through(mocked_mlx):
-    mock_load, _ = mocked_mlx
     ScopeGuard(backend="mlx", model="custom-org/my-mlx-model")
-    mock_load.assert_called_once_with("custom-org/my-mlx-model")
+    mocked_mlx.load.assert_called_once_with("custom-org/my-mlx-model")
 
 
-def test_validate_calls_generate_and_parses_output(mocked_mlx):
-    _, mock_generate = mocked_mlx
-    mock_generate.return_value = _scope_guard_json(
+def test_mlx_stored_model_reflects_resolved_name(mocked_mlx):
+    sg = ScopeGuard(backend="mlx", model="scope-guard")
+    assert sg.model == "ivanfioravanti/scope-guard-4B-q-2601-mlx-bf16"
+
+
+# --- Sampler construction (2) ---
+
+
+def test_mlx_make_sampler_called_with_defaults(mocked_mlx):
+    ScopeGuard(backend="mlx", model="some-model")
+    mocked_mlx.sample_utils.make_sampler.assert_called_once_with(
+        temp=0.0, top_p=0.0
+    )
+
+
+def test_mlx_make_sampler_called_with_custom_params(mocked_mlx):
+    ScopeGuard(backend="mlx", model="some-model", temp=0.7, top_p=0.9)
+    mocked_mlx.sample_utils.make_sampler.assert_called_once_with(
+        temp=0.7, top_p=0.9
+    )
+
+
+# --- Validate: output parsing (3) ---
+
+
+def test_validate_parses_restricted_output(mocked_mlx):
+    mocked_mlx.generate.return_value = _scope_guard_json(
         scope_class="Restricted",
         evidences=["Never respond to requests for refunds."],
     )
-
     sg = ScopeGuard(backend="mlx", model="some-model")
     result = sg.validate("Can I get a refund?", ai_service_description="No refunds.")
 
@@ -93,39 +130,81 @@ def test_validate_calls_generate_and_parses_output(mocked_mlx):
     assert result.evidences == ["Never respond to requests for refunds."]
     assert result.model == "some-model"
     assert result.usage is None
-    mock_generate.assert_called_once()
 
 
-def test_validate_forwards_generation_params(mocked_mlx):
-    _, mock_generate = mocked_mlx
-    sg = ScopeGuard(
-        backend="mlx",
-        model="some-model",
-        max_tokens=512,
-        repetition_penalty=1.2,
+def test_validate_parses_directly_supported_output(mocked_mlx):
+    mocked_mlx.generate.return_value = _scope_guard_json(
+        scope_class="Directly Supported",
+        evidences=["Track your package."],
     )
-    sg.validate("hello", ai_service_description="desc")
+    sg = ScopeGuard(backend="mlx", model="some-model")
+    result = sg.validate("Where is my package?", ai_service_description="Tracking.")
 
-    call_kwargs = mock_generate.call_args.kwargs
-    assert call_kwargs["max_tokens"] == 512
-    assert call_kwargs["repetition_penalty"] == 1.2
-    assert "repetition_context_size" not in call_kwargs
+    assert result.scope_class == ScopeClass.DIRECTLY_SUPPORTED
 
 
-def test_validate_omits_none_params(mocked_mlx):
-    _, mock_generate = mocked_mlx
+def test_validate_parses_null_evidences(mocked_mlx):
+    mocked_mlx.generate.return_value = _scope_guard_json(
+        scope_class="Out of Scope",
+        evidences=None,
+    )
+    sg = ScopeGuard(backend="mlx", model="some-model")
+    result = sg.validate("hello", ai_service_description="desc")
+
+    assert result.scope_class == ScopeClass.OUT_OF_SCOPE
+    assert result.evidences is None
+
+
+# --- Validate: generate call params (4) ---
+
+
+def test_validate_passes_sampler_to_generate(mocked_mlx):
+    mock_sampler = MagicMock()
+    mocked_mlx.sample_utils.make_sampler.return_value = mock_sampler
+
     sg = ScopeGuard(backend="mlx", model="some-model")
     sg.validate("hello", ai_service_description="desc")
 
-    call_kwargs = mock_generate.call_args.kwargs
+    call_kwargs = mocked_mlx.generate.call_args.kwargs
+    assert call_kwargs["sampler"] is mock_sampler
+    assert call_kwargs["max_tokens"] == 3000
+    assert call_kwargs["verbose"] is False
+
+
+def test_validate_forwards_max_tokens(mocked_mlx):
+    ScopeGuard(backend="mlx", model="some-model", max_tokens=512).validate(
+        "hello", ai_service_description="desc"
+    )
+    assert mocked_mlx.generate.call_args.kwargs["max_tokens"] == 512
+
+
+def test_validate_forwards_repetition_params(mocked_mlx):
+    ScopeGuard(
+        backend="mlx",
+        model="some-model",
+        repetition_penalty=1.2,
+        repetition_context_size=64,
+    ).validate("hello", ai_service_description="desc")
+
+    call_kwargs = mocked_mlx.generate.call_args.kwargs
+    assert call_kwargs["repetition_penalty"] == 1.2
+    assert call_kwargs["repetition_context_size"] == 64
+
+
+def test_validate_omits_none_optional_params(mocked_mlx):
+    ScopeGuard(backend="mlx", model="some-model").validate(
+        "hello", ai_service_description="desc"
+    )
+    call_kwargs = mocked_mlx.generate.call_args.kwargs
     assert "repetition_penalty" not in call_kwargs
     assert "repetition_context_size" not in call_kwargs
 
 
-def test_validate_calls_apply_chat_template(mocked_mlx):
-    mock_load, _ = mocked_mlx
-    mock_tokenizer = mock_load.return_value[1]
+# --- Prompt construction (1) ---
 
+
+def test_validate_calls_apply_chat_template(mocked_mlx):
+    mock_tokenizer = mocked_mlx.load.return_value[1]
     sg = ScopeGuard(backend="mlx", model="some-model")
     sg.validate("hello", ai_service_description="You are a bot.")
 
@@ -134,13 +213,49 @@ def test_validate_calls_apply_chat_template(mocked_mlx):
     assert call_kwargs["tokenize"] is False
     assert call_kwargs["add_generation_prompt"] is True
     assert call_kwargs["enable_thinking"] is False
-    messages = call_kwargs["args"][0] if call_kwargs.get("args") else call_kwargs.get("messages") or mock_tokenizer.apply_chat_template.call_args.args[0]
+    messages = mock_tokenizer.apply_chat_template.call_args.args[0]
     assert messages[0]["role"] == "system"
     assert messages[1]["role"] == "user"
 
 
+# --- Conversation input formats (3) ---
+
+
+def test_validate_accepts_dict_conversation(mocked_mlx):
+    sg = ScopeGuard(backend="mlx", model="some-model")
+    result = sg.validate(
+        {"role": "user", "content": "hello"}, ai_service_description="desc"
+    )
+    assert isinstance(result, ScopeGuardOutput)
+
+
+def test_validate_accepts_multi_turn_conversation(mocked_mlx):
+    sg = ScopeGuard(backend="mlx", model="some-model")
+    result = sg.validate(
+        [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+        ],
+        ai_service_description="desc",
+    )
+    assert isinstance(result, ScopeGuardOutput)
+
+
+def test_validate_accepts_structured_ai_service_description(mocked_mlx):
+    sg = ScopeGuard(backend="mlx", model="some-model")
+    svc = AIServiceDescription(
+        identity_role="Parcel delivery assistant",
+        context="Online logistics.",
+    )
+    result = sg.validate("hello", ai_service_description=svc)
+    assert isinstance(result, ScopeGuardOutput)
+
+
+# --- Batch validation (3) ---
+
+
 def test_batch_validate_with_shared_description(mocked_mlx):
-    _, mock_generate = mocked_mlx
     sg = ScopeGuard(backend="mlx", model="some-model")
     results = sg.batch_validate(
         ["q1", "q2"],
@@ -148,14 +263,13 @@ def test_batch_validate_with_shared_description(mocked_mlx):
     )
 
     assert len(results) == 2
-    assert mock_generate.call_count == 2
+    assert mocked_mlx.generate.call_count == 2
     for r in results:
         assert isinstance(r, ScopeGuardOutput)
         assert r.scope_class == ScopeClass.RESTRICTED
 
 
 def test_batch_validate_with_per_conversation_descriptions(mocked_mlx):
-    _, mock_generate = mocked_mlx
     sg = ScopeGuard(backend="mlx", model="some-model")
     results = sg.batch_validate(
         ["q1", "q2"],
@@ -163,24 +277,42 @@ def test_batch_validate_with_per_conversation_descriptions(mocked_mlx):
     )
 
     assert len(results) == 2
-    assert mock_generate.call_count == 2
+    assert mocked_mlx.generate.call_count == 2
+
+
+def test_batch_validate_empty_list_returns_empty(mocked_mlx):
+    sg = ScopeGuard(backend="mlx", model="some-model")
+    results = sg.batch_validate([], ai_service_description="desc")
+    assert results == []
+    mocked_mlx.generate.assert_not_called()
+
+
+# --- Skip evidences (1) ---
+
+
+def test_validate_skip_evidences_overrides_constructor(mocked_mlx):
+    mocked_mlx.generate.return_value = _scope_guard_json(evidences=None)
+    sg = ScopeGuard(backend="mlx", model="some-model", skip_evidences=False)
+    result = sg.validate(
+        "hello", ai_service_description="desc", skip_evidences=True
+    )
+    assert isinstance(result, ScopeGuardOutput)
+
+
+# --- Error handling (2) ---
 
 
 def test_validate_raises_on_invalid_json(mocked_mlx):
-    _, mock_generate = mocked_mlx
-    mock_generate.return_value = "not valid json"
-
+    mocked_mlx.generate.return_value = "not valid json"
     sg = ScopeGuard(backend="mlx", model="some-model")
     with pytest.raises(json.JSONDecodeError):
         sg.validate("hello", ai_service_description="desc")
 
 
 def test_validate_raises_on_invalid_scope_class(mocked_mlx):
-    _, mock_generate = mocked_mlx
-    mock_generate.return_value = json.dumps(
+    mocked_mlx.generate.return_value = json.dumps(
         {"scope_class": "INVALID_CLASS", "evidences": None}
     )
-
     sg = ScopeGuard(backend="mlx", model="some-model")
     with pytest.raises(Exception):
         sg.validate("hello", ai_service_description="desc")

--- a/uv.lock
+++ b/uv.lock
@@ -2216,6 +2216,59 @@ image = [
 ]
 
 [[package]]
+name = "mlx"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/7c/c16d52494a1ba6d90443f31fa26bc810bf878d532dfa9a7a13f49ef9542d/mlx-0.31.2-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:b29cf940f34205f09bb552ac60465ae833c4ae640b52777c6d725ddbad8461ca", size = 586942, upload-time = "2026-04-22T03:14:21.97Z" },
+    { url = "https://files.pythonhosted.org/packages/74/da/1c7f3dc39b7bda65b0cafbaf1e58a35eea118622c6f4506c9a4294c9806e/mlx-0.31.2-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:ebdc47b87b4b0216ceab3b5961716804bba3107c16454b65ae51d0e0c059f298", size = 586942, upload-time = "2026-04-22T03:14:23.527Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/e9/a8559389706d39f613620a8b6b42ed03cf3155a516b0762d355c5116fdab/mlx-0.31.2-cp310-cp310-macosx_26_0_arm64.whl", hash = "sha256:2a64db61b2840f28bae08354e6f999698e30381af201cc12354290673c96213b", size = 586804, upload-time = "2026-04-22T03:14:24.882Z" },
+    { url = "https://files.pythonhosted.org/packages/94/89/1e77ec3ff380e8fb9e7258047374d31452a0f9828a0e370f127b07dd8288/mlx-0.31.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4a3f181b367d404e44a6bd68ef5eb573930809ac60cacd51d0c851c629b1b651", size = 586911, upload-time = "2026-04-22T03:14:29.675Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/41/c1907f05f8a3fc54025fb78ad68d3c4a4b931664d03c0a24f7f431cc4087/mlx-0.31.2-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:70297cbef7479429f69c966bfed10da20a6f0c2aa997eec2b4f6ba1a07caf2ef", size = 586915, upload-time = "2026-04-22T03:14:31.403Z" },
+    { url = "https://files.pythonhosted.org/packages/97/b0/61ac2c14773c786fecbda28067b0207a0c654cb4d10c548808c51284d700/mlx-0.31.2-cp311-cp311-macosx_26_0_arm64.whl", hash = "sha256:c0ff158b7ac93a4b5659adbc70053498b30a5964fc45f78596398e056a96c36a", size = 587030, upload-time = "2026-04-22T03:14:32.961Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/47/5f33906cb03d6a378a697cd2d2641a26b37dea17ee3d9124d7e39e8eca01/mlx-0.31.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:e5067aaf2be1f3d7bba5be52348775804f111173c1ed04639618fd713b1a530f", size = 584863, upload-time = "2026-04-22T03:14:38.211Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e7/a851a451b1327af9fb4df3991b9ae87d066b6f6630e854af55c288b0995a/mlx-0.31.2-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:edb9797db7d852477ca1c99708058654ee860d4148fe5765f0d55528e2b1aa22", size = 584860, upload-time = "2026-04-22T03:14:39.746Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/15/0d1dc0597644e5e7b011ca954ba0c47e13cd880a3b909b0c3f1b4d8bf8f1/mlx-0.31.2-cp312-cp312-macosx_26_0_arm64.whl", hash = "sha256:51ca102db641b01e7cb083ce8ecb580e281530a141a7ca12544bb370641630ae", size = 584887, upload-time = "2026-04-22T03:14:41.585Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/3f/888f8664d4f8e23a1363a5f50024be5216e199ab7ad0ba20988c7ed6d729/mlx-0.31.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:1b3fb0dda955b0d552ce57bdd6f42b3309ab21b067e40587d6848443d307e91f", size = 584796, upload-time = "2026-04-22T03:14:47.215Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/14/e9cd18b51f9e1dbcb060eec0fafc2d2428c8e1eacd9b0a02d7c5ce75b661/mlx-0.31.2-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:34b0171cd9eb5c43fdd82091f6135d6ccc5a065363a4a3e68fac64fb4e53d37c", size = 584790, upload-time = "2026-04-22T03:14:48.519Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/20/c6c5fb998c7834d094b2bfb9f003b5246cb270f0266da055c55546c34999/mlx-0.31.2-cp313-cp313-macosx_26_0_arm64.whl", hash = "sha256:c05981684279a8935d58b0dde3ea5b02d210c3bad3319aa0e9934ec2df165752", size = 584795, upload-time = "2026-04-22T03:14:49.904Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f5/e63f6a9316ded2d14a8ebc7a9ca25734c784e8c54d064a78b4dceeacec0e/mlx-0.31.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:a13c9ce23c3deef6aa5a09315e7953e1a5dc311e851fa16fc74c81fb2509c0b9", size = 588417, upload-time = "2026-04-22T03:14:54.094Z" },
+    { url = "https://files.pythonhosted.org/packages/31/50/9d0c03ea3134cd85c132df7b0e4b75e6344bd8b4881a0b9c465cfa27f724/mlx-0.31.2-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:b0764bf11fc3a71dee988e19275eef67775cab63112d8bb7ef173ca8b2a1247c", size = 588421, upload-time = "2026-04-22T03:14:55.898Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5b/d364cc793bcb504621313acb55627cf0d5403ab2e0a594aa081cdbe4591f/mlx-0.31.2-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:59ccbd0f0044d4f97f11ebcbf0c480bc9e962935fd96275f120954afea65be8a", size = 588384, upload-time = "2026-04-22T03:14:57.439Z" },
+]
+
+[[package]]
+name = "mlx-lm"
+version = "0.31.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mlx", marker = "sys_platform == 'darwin'" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "pyyaml" },
+    { name = "sentencepiece" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/94/9a38d6b0c6fcca995b9136c94eb7da1e9c5165652edf228b96b29960fa7a/mlx_lm-0.31.3.tar.gz", hash = "sha256:61eb0e3ba09444f77f874aff295401d7ccd20b39495cbbce0c782a15474ce733", size = 304318, upload-time = "2026-04-22T07:37:27.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/02/9a67b8e4f87e3e2e5cd7b1ad79304b93c09a0db6af34bee75e6551c06c60/mlx_lm-0.31.3-py3-none-any.whl", hash = "sha256:758cfddf1180053b7613db76fad3d246a331a2a905808e1164a275621fc983b8", size = 408890, upload-time = "2026-04-22T07:37:25.965Z" },
+]
+
+[[package]]
+name = "mlx-metal"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/69/fe3b783ebe999f3118234e1e940feb622518bfb1dea6ac5d13b1d36a8449/mlx_metal-0.31.2-py3-none-macosx_14_0_arm64.whl", hash = "sha256:b25385bcee18fc194092255b8b53b9a3d8489eb650e59160f1b57aadd07aa2dc", size = 40055588, upload-time = "2026-04-22T03:14:14.43Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/5d/4c690d5b93c30ba002656c37363159d978705bf8eb801b8481840fb942c2/mlx_metal-0.31.2-py3-none-macosx_15_0_arm64.whl", hash = "sha256:e9d4e5fce6ca10a87a0e388597f99519ad594d09e674708b5312bd8bd4f5997d", size = 40053220, upload-time = "2026-04-22T03:14:18.048Z" },
+    { url = "https://files.pythonhosted.org/packages/99/82/11fd62a8d7a3e96e5c43220b17de0151e3f10101f8bb3b865f5bd9cdd074/mlx_metal-0.31.2-py3-none-macosx_26_0_arm64.whl", hash = "sha256:84ffb60ee503f03eb684f5fb168d5cff31e2a16b7f27c1731eaf7662bd6e9b46", size = 55792151, upload-time = "2026-04-22T03:14:22.059Z" },
+]
+
+[[package]]
 name = "model-hosting-container-standards"
 version = "0.1.14"
 source = { registry = "https://pypi.org/simple" }
@@ -2978,7 +3031,7 @@ wheels = [
 
 [[package]]
 name = "orbitals"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -2992,6 +3045,7 @@ all = [
     { name = "accelerate" },
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
+    { name = "mlx-lm" },
     { name = "nvidia-ml-py" },
     { name = "transformers" },
     { name = "uvicorn" },
@@ -3002,6 +3056,7 @@ scope-guard-all = [
     { name = "accelerate" },
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
+    { name = "mlx-lm" },
     { name = "nvidia-ml-py" },
     { name = "transformers" },
     { name = "uvicorn" },
@@ -3012,6 +3067,9 @@ scope-guard-hf = [
     { name = "accelerate" },
     { name = "nvidia-ml-py" },
     { name = "transformers" },
+]
+scope-guard-mlx = [
+    { name = "mlx-lm" },
 ]
 scope-guard-serve = [
     { name = "fastapi", extra = ["standard"] },
@@ -3049,10 +3107,12 @@ requires-dist = [
     { name = "aiohttp" },
     { name = "fastapi", extras = ["standard"], marker = "extra == 'serving'", specifier = ">=0.119.1" },
     { name = "httpx", marker = "extra == 'scope-guard-serve'" },
+    { name = "mlx-lm", marker = "extra == 'scope-guard-mlx'", specifier = ">=0.21.0" },
     { name = "nvidia-ml-py", marker = "extra == 'scope-guard-hf'" },
     { name = "nvidia-ml-py", marker = "extra == 'scope-guard-vllm'" },
     { name = "orbitals", extras = ["scope-guard-all"], marker = "extra == 'all'" },
     { name = "orbitals", extras = ["scope-guard-hf"], marker = "extra == 'scope-guard-all'" },
+    { name = "orbitals", extras = ["scope-guard-mlx"], marker = "extra == 'scope-guard-all'" },
     { name = "orbitals", extras = ["scope-guard-serve"], marker = "extra == 'scope-guard-all'" },
     { name = "orbitals", extras = ["scope-guard-vllm"], marker = "extra == 'scope-guard-all'" },
     { name = "orbitals", extras = ["scope-guard-vllm"], marker = "extra == 'scope-guard-serve'" },
@@ -3066,7 +3126,7 @@ requires-dist = [
     { name = "vllm", marker = "extra == 'scope-guard-vllm'", specifier = ">=0.19.1" },
     { name = "xgrammar", marker = "extra == 'scope-guard-vllm'" },
 ]
-provides-extras = ["serving", "scope-guard-hf", "scope-guard-vllm", "scope-guard-serve", "scope-guard-all", "all"]
+provides-extras = ["serving", "scope-guard-hf", "scope-guard-vllm", "scope-guard-mlx", "scope-guard-serve", "scope-guard-all", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Add MLX as a local ScopeGuard backend alongside the existing HF and vLLM backends, issue #18  

- Adds `ScopeGuard(backend="mlx")` with MLX model alias resolution, prompt construction, deterministic sampling defaults, generation parameter forwarding, JSON parsing, and batch validation support.
- Registers the MLX backend in the guard registry and exposes it through the existing `ScopeGuard` interface.
- Adds `orbitals[scope-guard-mlx]` optional dependency support via `mlx-lm`.
- Adds MLX backend tests covering construction, aliases, sampler configuration, prompt rendering, validation, batch validation, input formats, skip-evidence behavior, and error handling.
- Adds `examples/scope-guard/localbench.py` to compare HF vs MLX locally across 20 fixed ScopeGuard cases with ASCII timing tables.
- vllm backend used as "template"
## Test Plan
- `uv run pytest tests/test_mlx_backend.py`
- `python3 -m py_compile examples/scope-guard/localbench.py`
- Optionally run local comparison:
  - `uv run python examples/scope-guard/localbench.py`

As you can see below, on an M5 Max MLX is much faster. It works on CUDA too, I will test it on a 3090 TI in the next days as soon as I have time.

<img width="762" height="433" alt="image" src="https://github.com/user-attachments/assets/a7f73e1f-e2c0-45fe-accc-096c7a1a0755" />
