### PR TITLE
fix: set eos_token_id and pad_token_id in HF pipeline generate

### DIFF
--- a/src/hf_pipeline/scope_guard.py
+++ b/src/hf_pipeline/scope_guard.py
@@ -100,6 +100,8 @@ class ScopeGuardPipeline(Pipeline):
                 **tokenized,
                 max_new_tokens=self.max_new_tokens,
                 do_sample=self.do_sample,
+                eos_token_id=self.tokenizer.eos_token_id,
+                pad_token_id=self.tokenizer.pad_token_id,
             )
         return {
             "output_ids": outputs,


### PR DESCRIPTION
## Summary
- Pass the tokenizer's `eos_token_id` and `pad_token_id` to `model.generate` in `ScopeGuardPipeline._forward` so batched generation terminates and pads correctly rather than depending on model config defaults.

## Test plan
- [ ] Run a batched inference through `ScopeGuardPipeline` and confirm outputs terminate at EOS and padding is applied with the tokenizer's pad token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)