### PR TITLE
feat(claim-extractor): add 2B Qwen-family model alias

### DIFF
--- a/README.claim-extractor.md
+++ b/README.claim-extractor.md
@@ -13,11 +13,12 @@ Given a conversation (or a single message) and — optionally — the specificat
   * **Unverifiable** — common knowledge, subjective claims, marketing language, visual/UI references
 * **Intents** — explicit goals, requests, or actions the user wants to accomplish (extracted from user messages only)
 
-`claim-extractor` is a building block for a wide range of downstream governance tasks: fact-checking, intent routing, response auditing, and hallucination detection. It is powered by `claim-extractor-q`, an open-weight 4B model fine-tuned to extract atomic, self-contained claims and intents:
+`claim-extractor` is a building block for a wide range of downstream governance tasks: fact-checking, intent routing, response auditing, and hallucination detection. It is powered by open-weight Qwen-family models fine-tuned to extract atomic, self-contained claims and intents, released in two sizes:
 
 | Model | Parameters | Hosting |
 | :--- | :--- | :--- |
-| [`claim-extractor-q`](https://huggingface.co/principled-intelligence/claim-extractor-4B-q-2605) | 4B | Self-hosted (vLLM / HuggingFace) |
+| [`claim-extractor-4B-q`](https://huggingface.co/principled-intelligence/claim-extractor-4B-q-2605) | 4B | Self-hosted (vLLM / HuggingFace) |
+| [`claim-extractor-2B-q`](https://huggingface.co/principled-intelligence/claim-extractor-2B-q-2605) | 2B | Self-hosted (vLLM / HuggingFace) |
 
 ## Quickstart
 
@@ -38,7 +39,8 @@ from orbitals.claim_extractor import ClaimExtractor
 
 ce = ClaimExtractor(
     backend="vllm",  # or "hf" for huggingface
-    model="claim-extractor-q",
+    model="claim-extractor-4B-q",    # for the 4B Qwen-family model
+    # model="claim-extractor-2B-q",  # for the 2B Qwen-family model
 )
 
 ai_service_description = """
@@ -85,7 +87,8 @@ from orbitals.claim_extractor import ClaimExtractor
 
 ce = ClaimExtractor(
     backend="vllm",                   # or "hf"
-    model="claim-extractor-q",
+    model="claim-extractor-4B-q",     # for the 4B Qwen-family model
+    # model="claim-extractor-2B-q",   # for the 2B Qwen-family model
 )
 ```
 
@@ -119,7 +122,7 @@ Override them via the constructor (`ClaimExtractor(backend="vllm", enable_prefix
 ```python
 from orbitals.claim_extractor import ClaimExtractor, Claim, Intent
 
-ce = ClaimExtractor(backend="vllm", model="claim-extractor-q")
+ce = ClaimExtractor(backend="vllm", model="claim-extractor-4B-q")
 message = "Your package is in transit and will arrive on December 12, 2025."
 ai_service_description = "You are a virtual assistant for a parcel delivery service."
 
@@ -237,7 +240,7 @@ Only `identity_role` and `context` are required; every other field is optional.
 
 In addition to a decontextualized `content` string, every `Claim` and `Intent` is designed to carry a list of `evidences` — verbatim excerpts from the source message that support the extraction.
 
-> **Note**: the currently released `claim-extractor-q` model does **not** extract evidences — every `evidences` list will be empty. Evidence extraction is on the roadmap and will ship with a future model release. The `skip_evidences` flag on `ClaimExtractor` and the matching `--skip-evidences` serve flag are reserved for that future release; today they have no effect.
+> **Note**: the currently released `claim-extractor-4B-q` and `claim-extractor-2B-q` models do **not** extract evidences — every `evidences` list will be empty. Evidence extraction is on the roadmap and will ship with a future model release. The `skip_evidences` flag on `ClaimExtractor` and the matching `--skip-evidences` serve flag are reserved for that future release; today they have no effect.
 
 ### Batch Processing
 
@@ -284,11 +287,13 @@ All of this is configured via the `orbitals claim-extractor serve` command:
 # install the necessary packages
 uv add 'orbitals[claim-extractor-serve]'
 
-# start everything (defaults to "claim-extractor", which aliases to claim-extractor-q)
+# start everything (defaults to "claim-extractor", which aliases to claim-extractor-4B-q)
 orbitals claim-extractor serve --port 8000
 
 # or pin a specific model
-orbitals claim-extractor serve claim-extractor-q --port 8000
+orbitals claim-extractor serve claim-extractor-4B-q --port 8000
+# or use the smaller 2B model
+# orbitals claim-extractor serve claim-extractor-2B-q --port 8000
 ```
 
 Once the server is running, you can interact with it as follows:

--- a/scripts/test-readme-examples/claim-extractor/README.md
+++ b/scripts/test-readme-examples/claim-extractor/README.md
@@ -7,7 +7,7 @@ These complement the unit tests under [`tests/`](../../../tests/), which only
 mock the heavy paths. The scripts in this directory actually load real models,
 start the real FastAPI/vLLM server, and run real HTTP requests, so they require:
 
-- A CUDA-capable GPU (the `claim-extractor-q` model is 4B parameters)
+- A CUDA-capable GPU (the default `claim-extractor-4B-q` model is 4B parameters)
 - ~10 GB of disk for the Hugging Face download cache
 - The `vllm`, `transformers`, `accelerate`, `fastapi`, `uvicorn` extras installed
   (`./00-install-all.sh` will do this)

--- a/src/orbitals/claim_extractor/extractors/base.py
+++ b/src/orbitals/claim_extractor/extractors/base.py
@@ -22,6 +22,8 @@ DefaultModel = Literal["claim-extractor"]
 MODEL_MAPPING = {
     "claim-extractor": "principled-intelligence/claim-extractor-4B-q-2605",
     "claim-extractor-q": "principled-intelligence/claim-extractor-4B-q-2605",
+    "claim-extractor-4B-q": "principled-intelligence/claim-extractor-4B-q-2605",
+    "claim-extractor-2B-q": "principled-intelligence/claim-extractor-2B-q-2605",
 }
 
 

--- a/tests/test_claim_extractor.py
+++ b/tests/test_claim_extractor.py
@@ -23,23 +23,44 @@ from orbitals.claim_extractor.prompting import (
 from orbitals.types import AIServiceDescription
 
 
-def test_claim_extractor_default_alias_resolves_to_released_model():
+def test_claim_extractor_default_alias_resolves_to_4B_q_model():
     assert (
         ClaimExtractor.maybe_map_model("claim-extractor")
         == "principled-intelligence/claim-extractor-4B-q-2605"
     )
 
 
-def test_claim_extractor_q_alias_resolves_to_released_model():
+def test_claim_extractor_q_alias_resolves_to_4B_q_model():
     assert (
         ClaimExtractor.maybe_map_model("claim-extractor-q")
         == "principled-intelligence/claim-extractor-4B-q-2605"
     )
 
 
+def test_claim_extractor_4B_q_alias_resolves_to_4B_q_model():
+    assert (
+        ClaimExtractor.maybe_map_model("claim-extractor-4B-q")
+        == "principled-intelligence/claim-extractor-4B-q-2605"
+    )
+
+
+def test_claim_extractor_2B_q_alias_resolves_to_2B_q_model():
+    assert (
+        ClaimExtractor.maybe_map_model("claim-extractor-2B-q")
+        == "principled-intelligence/claim-extractor-2B-q-2605"
+    )
+
+
+def test_claim_extractor_unknown_model_name_is_passed_through_unchanged():
+    custom_name = "my-org/my-custom-model"
+    assert ClaimExtractor.maybe_map_model(custom_name) == custom_name
+
+
 def test_claim_extractor_model_mapping_contains_documented_aliases():
     assert "claim-extractor" in MODEL_MAPPING
     assert "claim-extractor-q" in MODEL_MAPPING
+    assert "claim-extractor-4B-q" in MODEL_MAPPING
+    assert "claim-extractor-2B-q" in MODEL_MAPPING
 
 
 def test_no_evidence_response_validates_and_converts_to_full_extractions():


### PR DESCRIPTION
## What & Why
Expose the newly-released `principled-intelligence/claim-extractor-2B-q-2605` (2B Qwen-family) model alongside the existing 4B model, so users can pick the smaller variant when GPU resources are tight. Adopts a `-<size>-<family>` alias convention that mirrors `scope_guard`'s multi-variant `MODEL_MAPPING`.

## Changes
- `MODEL_MAPPING` in `src/orbitals/claim_extractor/extractors/base.py` now has four entries: the default `claim-extractor` and back-compat `claim-extractor-q` continue to resolve to the 4B model, while the new explicit `claim-extractor-4B-q` and `claim-extractor-2B-q` aliases give callers a clear way to select a size.
- README adds a row for the 2B model in the model table, switches code snippets to the explicit `claim-extractor-4B-q` alias with a commented `claim-extractor-2B-q` sibling (mirroring the `scope-guard` README style), and refreshes the evidence/serve notes.
- Tests cover all four aliases plus a pass-through case, mirroring `tests/test_model_mapping.py` for `scope_guard`.

## Testing
- `uv run pytest tests/test_claim_extractor.py -v` → 17 passed.
- `uv run orbitals claim-extractor convert-default-model-name claim-extractor-2B-q` → `principled-intelligence/claim-extractor-2B-q-2605`.
- Same CLI smoke-checked for `claim-extractor-4B-q` and a custom (pass-through) name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)