### PR TITLE
feat(claim-extractor): add intents_only stopping criterion to all backends

### DIFF
--- a/README.claim-extractor.md
+++ b/README.claim-extractor.md
@@ -141,6 +141,37 @@ for intent in result.extractions.intents:
 
 Each `Claim` and `Intent` carries a decontextualized `content` string. An `evidences` field is also present on every extraction (see [Evidences](#evidences) below), but the currently released model does not populate it — it will always be an empty list.
 
+### Intents only
+
+If you only care about the user's **intents** and don't need claims, set `intents_only=True`. This applies a stopping criterion that halts generation as soon as the intents are produced — the model never generates the (often much larger) claims section, so extraction is faster and cheaper. The returned `claims` list is always empty in this mode.
+
+```python
+from orbitals.claim_extractor import ClaimExtractor
+
+ce = ClaimExtractor(backend="vllm", model="claim-extractor-4B-q", intents_only=True)
+
+result = ce.extract(
+    {"role": "user", "content": "Can you book me an appointment for next Tuesday morning?"},
+    ai_service_description=ai_service_description,
+)
+
+for intent in result.extractions.intents:
+    print(intent.content)
+
+assert result.extractions.claims == []
+```
+
+`intents_only` is supported on every backend (`vllm`, `hf`, `api`) and is available both as a constructor default and as a per-call override on `extract` / `batch_extract`:
+
+```python
+ce = ClaimExtractor(backend="vllm", model="claim-extractor-4B-q")  # default: full extraction
+
+# override per call — extract only intents for this request
+result = ce.extract(message, ai_service_description=ai_service_description, intents_only=True)
+```
+
+When serving, set the server-side default with the `--intents-only` flag on `orbitals claim-extractor serve`, or pass `"intents_only": true` on individual requests (see [Serving](#serving-claimextractor-on-premise-or-on-your-infrastructure) below).
+
 ### Claim subtypes
 
 ```python
@@ -294,7 +325,12 @@ orbitals claim-extractor serve --port 8000
 orbitals claim-extractor serve claim-extractor-4B-q --port 8000
 # or use the smaller 2B model
 # orbitals claim-extractor serve claim-extractor-2B-q --port 8000
+
+# extract only intents by default (stops generation before claims)
+# orbitals claim-extractor serve --intents-only --port 8000
 ```
+
+`--intents-only` sets the server-side default; individual requests can still override it by passing `"intents_only": true` (or `false`) in the request body. See [Intents only](#intents-only).
 
 Once the server is running, you can interact with it as follows:
 

--- a/src/hf_pipeline/claim_extractor.py
+++ b/src/hf_pipeline/claim_extractor.py
@@ -19,6 +19,7 @@ class ClaimExtractionPipeline(Pipeline):
         model,
         tokenizer=None,
         skip_evidences: bool = True,
+        intents_only: bool = False,
         max_new_tokens: int = 20_000,
         do_sample: bool = True,
         temperature: float = 0.7,
@@ -46,6 +47,7 @@ class ClaimExtractionPipeline(Pipeline):
                 tokenizer.pad_token = tokenizer.eos_token
 
         self.skip_evidences = skip_evidences
+        self.intents_only = intents_only
         self.max_new_tokens = max_new_tokens
         self.do_sample = do_sample
         self.temperature = temperature
@@ -63,10 +65,13 @@ class ClaimExtractionPipeline(Pipeline):
         preprocess_kwargs = {
             "skip_evidences": kwargs.get("skip_evidences", self.skip_evidences)
         }
+        forward_kwargs = {
+            "intents_only": kwargs.get("intents_only", self.intents_only)
+        }
 
         return (
             preprocess_kwargs,
-            {},
+            forward_kwargs,
             {},
         )
 
@@ -95,7 +100,7 @@ class ClaimExtractionPipeline(Pipeline):
 
         return {"text": text}
 
-    def _forward(self, model_inputs):
+    def _forward(self, model_inputs, intents_only: bool = False):
         tokenized = self.tokenizer(
             model_inputs["text"],
             return_tensors="pt",
@@ -103,16 +108,27 @@ class ClaimExtractionPipeline(Pipeline):
             truncation=True,
         ).to(self.device)
 
+        generate_kwargs = dict(
+            max_new_tokens=self.max_new_tokens,
+            do_sample=self.do_sample,
+            temperature=self.temperature,
+            repetition_penalty=self.repetition_penalty,
+            top_p=self.top_p,
+            top_k=self.top_k,
+            min_p=self.min_p,
+        )
+        if intents_only:
+            # Stop as soon as the model starts the `"claims"` key, so only the
+            # intents are generated. The truncated JSON is repaired downstream.
+            generate_kwargs["stop_strings"] = [
+                orbitals.claim_extractor.prompting.CLAIMS_STOP_STRING
+            ]
+            generate_kwargs["tokenizer"] = self.tokenizer
+
         with torch.inference_mode():
             outputs = self.model.generate(
                 **tokenized,
-                max_new_tokens=self.max_new_tokens,
-                do_sample=self.do_sample,
-                temperature=self.temperature,
-                repetition_penalty=self.repetition_penalty,
-                top_p=self.top_p,
-                top_k=self.top_k,
-                min_p=self.min_p,
+                **generate_kwargs,
             )
         return {
             "output_ids": outputs,

--- a/src/orbitals/claim_extractor/cli/serve.py
+++ b/src/orbitals/claim_extractor/cli/serve.py
@@ -33,6 +33,10 @@ def serve(
         "claim-extractor", help="The model used for vLLM serving"
     ),
     skip_evidences: bool = typer.Option(True, help="Whether to skip evidences"),
+    intents_only: bool = typer.Option(
+        False,
+        help="Only extract intents (stop generation before claims) by default",
+    ),
     port: int = typer.Option(
         8000, "-p", "--port", help="The port to use for the server"
     ),
@@ -91,6 +95,7 @@ def serve(
     os.environ["CLAIM_EXTRACTOR_VLLM_MODEL"] = vllm_model
     os.environ["CLAIM_EXTRACTOR_VLLM_SERVING_URL"] = f"http://localhost:{vllm_port}"
     os.environ["CLAIM_EXTRACTOR_SKIP_EVIDENCES"] = str(1) if skip_evidences else str(0)
+    os.environ["CLAIM_EXTRACTOR_INTENTS_ONLY"] = str(1) if intents_only else str(0)
     os.environ["CLAIM_EXTRACTOR_TEMPERATURE"] = str(temperature)
     os.environ["CLAIM_EXTRACTOR_FREQUENCY_PENALTY"] = str(frequency_penalty)
     os.environ["CLAIM_EXTRACTOR_PRESENCE_PENALTY"] = str(presence_penalty)

--- a/src/orbitals/claim_extractor/extractors/api.py
+++ b/src/orbitals/claim_extractor/extractors/api.py
@@ -18,6 +18,7 @@ def _build_request_data(
     model: str,
     conversation: ClaimExtractorInput,
     skip_evidences: bool,
+    intents_only: bool,
     ai_service_description: str | AIServiceDescription | None,
 ) -> dict:
     return {
@@ -33,6 +34,7 @@ def _build_request_data(
             else {}
         ),
         "skip_evidences": skip_evidences,
+        "intents_only": intents_only,
     }
 
 
@@ -40,6 +42,7 @@ def _build_batch_request_data(
     model: str,
     conversations: list[ClaimExtractorInput],
     skip_evidences: bool,
+    intents_only: bool,
     ai_service_description: str | AIServiceDescription | None = None,
     ai_service_descriptions: list[str] | list[AIServiceDescription] | None = None,
 ) -> dict:
@@ -69,6 +72,7 @@ def _build_batch_request_data(
             else {}
         ),
         "skip_evidences": skip_evidences,
+        "intents_only": intents_only,
     }
 
 
@@ -100,6 +104,7 @@ class APIClaimExtractor(ClaimExtractor):
         api_url: str = "http://localhost:8000",
         api_key: str | None = None,
         skip_evidences: bool = True,
+        intents_only: bool = False,
         custom_headers: dict[str, str] | None = None,
     ):
         super().__init__(backend)
@@ -107,6 +112,7 @@ class APIClaimExtractor(ClaimExtractor):
         self.api_url = api_url
         self.api_key = _maybe_get_api_key(api_key, custom_headers)
         self.skip_evidences = skip_evidences
+        self.intents_only = intents_only
         self.custom_headers = dict(custom_headers) if custom_headers is not None else {}
         if self.api_key is not None:
             self.custom_headers["X-API-Key"] = self.api_key
@@ -117,6 +123,7 @@ class APIClaimExtractor(ClaimExtractor):
         *,
         ai_service_description: str | AIServiceDescription | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         model: str | None = None,
         **kwargs,
     ) -> ClaimExtractorOutput:
@@ -128,6 +135,9 @@ class APIClaimExtractor(ClaimExtractor):
                 skip_evidences=skip_evidences
                 if skip_evidences is not None
                 else self.skip_evidences,
+                intents_only=intents_only
+                if intents_only is not None
+                else self.intents_only,
                 ai_service_description=ai_service_description,
             ),
             headers={**self.custom_headers, "Content-Type": "application/json"},
@@ -148,6 +158,7 @@ class APIClaimExtractor(ClaimExtractor):
         ai_service_description: str | AIServiceDescription | None = None,
         ai_service_descriptions: list[str] | list[AIServiceDescription] | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         model: str | None = None,
         **kwargs,
     ) -> list[ClaimExtractorOutput]:
@@ -159,6 +170,9 @@ class APIClaimExtractor(ClaimExtractor):
                 skip_evidences=skip_evidences
                 if skip_evidences is not None
                 else self.skip_evidences,
+                intents_only=intents_only
+                if intents_only is not None
+                else self.intents_only,
                 ai_service_description=ai_service_description,
                 ai_service_descriptions=ai_service_descriptions,
             ),
@@ -186,6 +200,7 @@ class AsyncAPIClaimExtractor(AsyncClaimExtractor):
         api_url: str = "http://localhost:8000",
         api_key: str | None = None,
         skip_evidences: bool = True,
+        intents_only: bool = False,
         custom_headers: dict[str, str] | None = None,
     ):
         super().__init__(backend)
@@ -193,6 +208,7 @@ class AsyncAPIClaimExtractor(AsyncClaimExtractor):
         self.api_url = api_url
         self.api_key = _maybe_get_api_key(api_key, custom_headers)
         self.skip_evidences = skip_evidences
+        self.intents_only = intents_only
         self.custom_headers = dict(custom_headers) if custom_headers is not None else {}
         if self.api_key is not None:
             self.custom_headers["X-API-Key"] = self.api_key
@@ -203,6 +219,7 @@ class AsyncAPIClaimExtractor(AsyncClaimExtractor):
         *,
         ai_service_description: str | AIServiceDescription | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         model: str | None = None,
         **kwargs,
     ) -> ClaimExtractorOutput:
@@ -215,6 +232,9 @@ class AsyncAPIClaimExtractor(AsyncClaimExtractor):
                     skip_evidences=skip_evidences
                     if skip_evidences is not None
                     else self.skip_evidences,
+                    intents_only=intents_only
+                    if intents_only is not None
+                    else self.intents_only,
                     ai_service_description=ai_service_description,
                 ),
                 headers={**self.custom_headers, "Content-Type": "application/json"},
@@ -235,6 +255,7 @@ class AsyncAPIClaimExtractor(AsyncClaimExtractor):
         ai_service_description: str | AIServiceDescription | None = None,
         ai_service_descriptions: list[str] | list[AIServiceDescription] | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         model: str | None = None,
         **kwargs,
     ) -> list[ClaimExtractorOutput]:
@@ -247,6 +268,9 @@ class AsyncAPIClaimExtractor(AsyncClaimExtractor):
                     skip_evidences=skip_evidences
                     if skip_evidences is not None
                     else self.skip_evidences,
+                    intents_only=intents_only
+                    if intents_only is not None
+                    else self.intents_only,
                     ai_service_description=ai_service_description,
                     ai_service_descriptions=ai_service_descriptions,
                 ),

--- a/src/orbitals/claim_extractor/extractors/base.py
+++ b/src/orbitals/claim_extractor/extractors/base.py
@@ -138,6 +138,7 @@ class ClaimExtractor(BaseClaimExtractor):
         backend: Literal["hf"] = "hf",
         model: DefaultModel | str = "claim-extractor",
         skip_evidences: bool = True,
+        intents_only: bool = False,
         max_new_tokens: int = 20_000,
         do_sample: bool = False,
         temperature: float = 0.7,
@@ -156,6 +157,7 @@ class ClaimExtractor(BaseClaimExtractor):
         backend: Literal["vllm"],
         model: DefaultModel | str = "claim-extractor",
         skip_evidences: bool = True,
+        intents_only: bool = False,
         temperature: float = 0.7,
         max_tokens: int = 20_000,
         max_model_len: int = 40_000,
@@ -180,6 +182,7 @@ class ClaimExtractor(BaseClaimExtractor):
         api_url: str = "http://localhost:8000",
         api_key: str | None = None,
         skip_evidences: bool = True,
+        intents_only: bool = False,
         custom_headers: dict[str, str] | None = None,
     ) -> APIClaimExtractor: ...
 
@@ -192,6 +195,7 @@ class ClaimExtractor(BaseClaimExtractor):
         *,
         ai_service_description: str | AIServiceDescription | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         **kwargs,
     ) -> ClaimExtractorOutput:
         conversation = self._validate_conversation(conversation)
@@ -199,6 +203,7 @@ class ClaimExtractor(BaseClaimExtractor):
             conversation,
             ai_service_description=ai_service_description,
             skip_evidences=skip_evidences,
+            intents_only=intents_only,
             **kwargs,
         )
 
@@ -208,6 +213,7 @@ class ClaimExtractor(BaseClaimExtractor):
         *,
         ai_service_description: str | AIServiceDescription | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         **kwargs,
     ) -> ClaimExtractorOutput:
         raise NotImplementedError
@@ -219,6 +225,7 @@ class ClaimExtractor(BaseClaimExtractor):
         ai_service_description: str | AIServiceDescription | None = None,
         ai_service_descriptions: list[str] | list[AIServiceDescription] | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         **kwargs,
     ) -> list[ClaimExtractorOutput]:
         if len(conversations) == 0:
@@ -234,6 +241,7 @@ class ClaimExtractor(BaseClaimExtractor):
             ai_service_description=ai_service_description,
             ai_service_descriptions=ai_service_descriptions,
             skip_evidences=skip_evidences,
+            intents_only=intents_only,
             **kwargs,
         )
 
@@ -244,6 +252,7 @@ class ClaimExtractor(BaseClaimExtractor):
         ai_service_description: str | AIServiceDescription | None = None,
         ai_service_descriptions: list[str] | list[AIServiceDescription] | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         **kwargs,
     ) -> list[ClaimExtractorOutput]:
         raise NotImplementedError
@@ -256,6 +265,7 @@ class AsyncClaimExtractor(BaseClaimExtractor):
         backend: Literal["vllm-api"],
         model: DefaultModel | str = "claim-extractor",
         skip_evidences: bool = True,
+        intents_only: bool = False,
         vllm_serving_url: str = "http://localhost:8000",
         temperature: float = 0.7,
         max_tokens: int = 20_000,
@@ -277,6 +287,7 @@ class AsyncClaimExtractor(BaseClaimExtractor):
         api_url: str = "http://localhost:8000",
         api_key: str | None = None,
         skip_evidences: bool = True,
+        intents_only: bool = False,
         custom_headers: dict[str, str] | None = None,
     ) -> AsyncAPIClaimExtractor: ...
 
@@ -289,6 +300,7 @@ class AsyncClaimExtractor(BaseClaimExtractor):
         *,
         ai_service_description: str | AIServiceDescription | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         **kwargs,
     ) -> ClaimExtractorOutput:
         conversation = self._validate_conversation(conversation)
@@ -296,6 +308,7 @@ class AsyncClaimExtractor(BaseClaimExtractor):
             conversation,
             ai_service_description=ai_service_description,
             skip_evidences=skip_evidences,
+            intents_only=intents_only,
             **kwargs,
         )
 
@@ -305,6 +318,7 @@ class AsyncClaimExtractor(BaseClaimExtractor):
         *,
         ai_service_description: str | AIServiceDescription | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         **kwargs,
     ) -> ClaimExtractorOutput:
         raise NotImplementedError
@@ -316,6 +330,7 @@ class AsyncClaimExtractor(BaseClaimExtractor):
         ai_service_description: str | AIServiceDescription | None = None,
         ai_service_descriptions: list[str] | list[AIServiceDescription] | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         **kwargs,
     ) -> list[ClaimExtractorOutput]:
         if len(conversations) == 0:
@@ -331,6 +346,7 @@ class AsyncClaimExtractor(BaseClaimExtractor):
             ai_service_description=ai_service_description,
             ai_service_descriptions=ai_service_descriptions,
             skip_evidences=skip_evidences,
+            intents_only=intents_only,
             **kwargs,
         )
 
@@ -341,6 +357,7 @@ class AsyncClaimExtractor(BaseClaimExtractor):
         ai_service_description: str | AIServiceDescription | None = None,
         ai_service_descriptions: list[str] | list[AIServiceDescription] | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         **kwargs,
     ) -> list[ClaimExtractorOutput]:
         raise NotImplementedError

--- a/src/orbitals/claim_extractor/extractors/hf.py
+++ b/src/orbitals/claim_extractor/extractors/hf.py
@@ -9,6 +9,7 @@ from ..modeling import (
     ClaimExtractorOutput,
     _parse_raw_output,
 )
+from ..prompting import parse_intents_only_output
 from .base import ClaimExtractor, DefaultModel
 
 
@@ -19,6 +20,7 @@ class HuggingFaceClaimExtractor(ClaimExtractor):
         backend: Literal["hf"] = "hf",
         model: DefaultModel | str = "claim-extractor",
         skip_evidences: bool = True,
+        intents_only: bool = False,
         max_new_tokens: int = 20_000,
         do_sample: bool = True,
         temperature: float = 0.7,
@@ -39,11 +41,13 @@ class HuggingFaceClaimExtractor(ClaimExtractor):
         super().__init__(backend)
         self.model = self.maybe_map_model(model)
         self.skip_evidences = skip_evidences
+        self.intents_only = intents_only
         self._pipeline = pipeline(
             task="claim-extraction",
             model=self.model,
             trust_remote_code=True,
             skip_evidences=skip_evidences,
+            intents_only=intents_only,
             max_new_tokens=max_new_tokens,
             do_sample=do_sample,
             temperature=temperature,
@@ -59,11 +63,19 @@ class HuggingFaceClaimExtractor(ClaimExtractor):
     def _resolve_flags(
         self,
         skip_evidences: bool | None,
+        intents_only: bool | None,
     ) -> dict[str, bool]:
         resolved: dict[str, bool] = {}
         if skip_evidences is not None:
             resolved["skip_evidences"] = skip_evidences
+        if intents_only is not None:
+            resolved["intents_only"] = intents_only
         return resolved
+
+    def _parse_generated_text(self, generated_text: str, intents_only: bool):
+        if intents_only:
+            return parse_intents_only_output(generated_text)
+        return _parse_raw_output(generated_text)
 
     def _extract(
         self,
@@ -71,15 +83,19 @@ class HuggingFaceClaimExtractor(ClaimExtractor):
         *,
         ai_service_description: str | AIServiceDescription | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         **kwargs,
     ) -> ClaimExtractorOutput:
-        pipeline_kwargs = self._resolve_flags(skip_evidences)
+        resolved_intents_only = (
+            intents_only if intents_only is not None else self.intents_only
+        )
+        pipeline_kwargs = self._resolve_flags(skip_evidences, intents_only)
         generated_text = self._pipeline(
             inputs=(conversation, ai_service_description),
             **pipeline_kwargs,
         )[0]["generated_text"]
 
-        extractions = _parse_raw_output(generated_text)
+        extractions = self._parse_generated_text(generated_text, resolved_intents_only)
 
         return ClaimExtractorOutput(
             extractions=extractions,
@@ -94,8 +110,12 @@ class HuggingFaceClaimExtractor(ClaimExtractor):
         ai_service_description: str | AIServiceDescription | None = None,
         ai_service_descriptions: list[str] | list[AIServiceDescription] | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         **kwargs,
     ) -> list[ClaimExtractorOutput]:
+        resolved_intents_only = (
+            intents_only if intents_only is not None else self.intents_only
+        )
         if ai_service_descriptions is not None:
             pipeline_inputs = [
                 (c, ad) for c, ad in zip(conversations, ai_service_descriptions)
@@ -103,7 +123,7 @@ class HuggingFaceClaimExtractor(ClaimExtractor):
         else:
             pipeline_inputs = [(c, ai_service_description) for c in conversations]
 
-        pipeline_kwargs = self._resolve_flags(skip_evidences)
+        pipeline_kwargs = self._resolve_flags(skip_evidences, intents_only)
         pipeline_outputs = self._pipeline(
             pipeline_inputs,
             **pipeline_kwargs,
@@ -113,7 +133,9 @@ class HuggingFaceClaimExtractor(ClaimExtractor):
 
         for pipeline_output in pipeline_outputs:
             generated_text = pipeline_output[0]["generated_text"]
-            extractions = _parse_raw_output(generated_text)
+            extractions = self._parse_generated_text(
+                generated_text, resolved_intents_only
+            )
             results.append(
                 ClaimExtractorOutput(
                     extractions=extractions,

--- a/src/orbitals/claim_extractor/extractors/vllm.py
+++ b/src/orbitals/claim_extractor/extractors/vllm.py
@@ -18,8 +18,10 @@ from ..modeling import (
     ClaimExtractorOutput,
 )
 from ..prompting import (
+    CLAIMS_STOP_STRING,
     build_prompt,
     get_system_prompt,
+    parse_intents_only_output,
     validate_extractions_response,
 )
 from .base import AsyncClaimExtractor, ClaimExtractor, DefaultModel
@@ -63,6 +65,7 @@ class VLLMClaimExtractor(ClaimExtractor):
         backend: Literal["vllm"] = "vllm",
         model: DefaultModel | str = "claim-extractor",
         skip_evidences: bool = True,
+        intents_only: bool = False,
         temperature: float = 0.7,
         max_tokens: int = 20_000,
         max_model_len: int = 40_000,
@@ -89,6 +92,7 @@ class VLLMClaimExtractor(ClaimExtractor):
         super().__init__(backend)
         self.model = self.maybe_map_model(model)
         self.skip_evidences = skip_evidences
+        self.intents_only = intents_only
         if speculative_config is _USE_DEFAULT_SPECULATIVE_CONFIG:
             speculative_config = dict(_DEFAULT_SPECULATIVE_CONFIG)
         self.llm = vllm.LLM(
@@ -118,12 +122,14 @@ class VLLMClaimExtractor(ClaimExtractor):
         *,
         ai_service_description: str | AIServiceDescription | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         **kwargs,
     ) -> ClaimExtractorOutput:
         return self._batch_extract(
             [conversation],
             ai_service_description=ai_service_description,
             skip_evidences=skip_evidences,
+            intents_only=intents_only,
         )[0]
 
     def _batch_extract(
@@ -133,10 +139,14 @@ class VLLMClaimExtractor(ClaimExtractor):
         ai_service_description: str | AIServiceDescription | None = None,
         ai_service_descriptions: list[str] | list[AIServiceDescription] | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         **kwargs,
     ) -> list[ClaimExtractorOutput]:
         resolved_skip_evidences = (
             skip_evidences if skip_evidences is not None else self.skip_evidences
+        )
+        resolved_intents_only = (
+            intents_only if intents_only is not None else self.intents_only
         )
 
         if ai_service_descriptions is not None:
@@ -156,25 +166,35 @@ class VLLMClaimExtractor(ClaimExtractor):
             for c, ad in zip(conversations, descriptions)
         ]
 
-        outputs = self.llm.generate(prompts, self.sampling_params, use_tqdm=False)
+        if resolved_intents_only:
+            sampling_params = self.sampling_params.clone()
+            sampling_params.stop = [CLAIMS_STOP_STRING]
+        else:
+            sampling_params = self.sampling_params
+
+        outputs = self.llm.generate(prompts, sampling_params, use_tqdm=False)
 
         results: list[ClaimExtractorOutput] = []
 
         for output in outputs:
             text = output.outputs[0].text
 
-            # TODO generation errors: handle potentially invalid JSON (retry?)
-            parsed_obj = _strip_lone_surrogates(json.loads(text))
+            if resolved_intents_only:
+                extractions = parse_intents_only_output(text)
+            else:
+                # TODO generation errors: handle potentially invalid JSON (retry?)
+                parsed_obj = _strip_lone_surrogates(json.loads(text))
 
-            # TODO generation errors: handle model validation failure (retry?)
-            validated_obj = validate_extractions_response(
-                parsed_obj,
-                skip_evidences=resolved_skip_evidences,
-            )
+                # TODO generation errors: handle model validation failure (retry?)
+                validated_obj = validate_extractions_response(
+                    parsed_obj,
+                    skip_evidences=resolved_skip_evidences,
+                )
+                extractions = validated_obj.extractions
 
             results.append(
                 ClaimExtractorOutput(
-                    extractions=validated_obj.extractions,
+                    extractions=extractions,
                     model=self.model,
                     usage=None,
                 )
@@ -190,6 +210,7 @@ class AsyncVLLMApiClaimExtractor(AsyncClaimExtractor):
         backend: Literal["vllm-api"] = "vllm-api",
         model: DefaultModel | str = "claim-extractor",
         skip_evidences: bool = True,
+        intents_only: bool = False,
         vllm_serving_url: str = "http://localhost:8000",
         temperature: float = 0.7,
         max_tokens: int = 20_000,
@@ -210,6 +231,7 @@ class AsyncVLLMApiClaimExtractor(AsyncClaimExtractor):
             else self.default_model_name
         )
         self.skip_evidences = skip_evidences
+        self.intents_only = intents_only
         self.vllm_serving_url = vllm_serving_url
         self.vllm_temperature = temperature
         self.vllm_max_tokens = max_tokens
@@ -227,6 +249,7 @@ class AsyncVLLMApiClaimExtractor(AsyncClaimExtractor):
         conversation: ClaimExtractorInput,
         ai_service_description: str | AIServiceDescription | None,
         skip_evidences: bool | None,
+        intents_only: bool | None,
         prefill: bool,
         chat_templating_tokenizer: str | None = None,
     ) -> ClaimExtractorOutput:
@@ -245,6 +268,9 @@ class AsyncVLLMApiClaimExtractor(AsyncClaimExtractor):
         resolved_skip_evidences = (
             skip_evidences if skip_evidences is not None else self.skip_evidences
         )
+        resolved_intents_only = (
+            intents_only if intents_only is not None else self.intents_only
+        )
 
         prompt = build_prompt(
             tokenizer=tokenizer,
@@ -254,39 +280,47 @@ class AsyncVLLMApiClaimExtractor(AsyncClaimExtractor):
             prefill=prefill,
         )
 
+        request_body = {
+            "model": model_name,
+            "prompt": prompt,
+            "temperature": self.vllm_temperature,
+            "max_tokens": self.vllm_max_tokens,
+            "frequency_penalty": self.vllm_frequency_penalty,
+            "presence_penalty": self.vllm_presence_penalty,
+            "repetition_penalty": self.vllm_repetition_penalty,
+            "top_p": self.vllm_top_p,
+            "top_k": self.vllm_top_k,
+            "min_p": self.vllm_min_p,
+        }
+        if resolved_intents_only:
+            request_body["stop"] = [CLAIMS_STOP_STRING]
+
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 f"{self.vllm_serving_url}/v1/completions",
-                json={
-                    "model": model_name,
-                    "prompt": prompt,
-                    "temperature": self.vllm_temperature,
-                    "max_tokens": self.vllm_max_tokens,
-                    "frequency_penalty": self.vllm_frequency_penalty,
-                    "presence_penalty": self.vllm_presence_penalty,
-                    "repetition_penalty": self.vllm_repetition_penalty,
-                    "top_p": self.vllm_top_p,
-                    "top_k": self.vllm_top_k,
-                    "min_p": self.vllm_min_p,
-                },
+                json=request_body,
                 headers={"Content-Type": "application/json"},
             ) as response:
                 response.raise_for_status()
                 response_json = await response.json()
                 response_text = response_json["choices"][0]["text"]
 
-        try:
-            parsed_obj = _strip_lone_surrogates(json.loads(response_text))
-        except json.JSONDecodeError:
-            raise ValueError(f"Failed to parse generated text: {response_json}")
+        if resolved_intents_only:
+            extractions = parse_intents_only_output(response_text)
+        else:
+            try:
+                parsed_obj = _strip_lone_surrogates(json.loads(response_text))
+            except json.JSONDecodeError:
+                raise ValueError(f"Failed to parse generated text: {response_json}")
 
-        try:
-            validated_obj = validate_extractions_response(
-                parsed_obj,
-                skip_evidences=resolved_skip_evidences,
-            )
-        except pydantic.ValidationError as e:
-            raise ValueError(f"Failed to validate generated text: {e}")
+            try:
+                validated_obj = validate_extractions_response(
+                    parsed_obj,
+                    skip_evidences=resolved_skip_evidences,
+                )
+            except pydantic.ValidationError as e:
+                raise ValueError(f"Failed to validate generated text: {e}")
+            extractions = validated_obj.extractions
 
         system_prompt_tokens = (
             0
@@ -295,7 +329,7 @@ class AsyncVLLMApiClaimExtractor(AsyncClaimExtractor):
         )
 
         return ClaimExtractorOutput(
-            extractions=validated_obj.extractions,
+            extractions=extractions,
             model=model_name,
             # TODO usage implementation is mocked
             usage=LLMUsage(
@@ -313,6 +347,7 @@ class AsyncVLLMApiClaimExtractor(AsyncClaimExtractor):
         *,
         ai_service_description: str | AIServiceDescription | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         model: str | None = None,
         chat_templating_tokenizer: str | None = None,
         **kwargs,
@@ -321,6 +356,7 @@ class AsyncVLLMApiClaimExtractor(AsyncClaimExtractor):
             conversations=[conversation],
             ai_service_description=ai_service_description,
             skip_evidences=skip_evidences,
+            intents_only=intents_only,
             model=model,
             chat_templating_tokenizer=chat_templating_tokenizer,
         )
@@ -333,6 +369,7 @@ class AsyncVLLMApiClaimExtractor(AsyncClaimExtractor):
         ai_service_description: str | AIServiceDescription | None = None,
         ai_service_descriptions: list[str] | list[AIServiceDescription] | None = None,
         skip_evidences: bool | None = None,
+        intents_only: bool | None = None,
         model: str | None = None,
         chat_templating_tokenizer: str | None = None,
         **kwargs,
@@ -355,6 +392,7 @@ class AsyncVLLMApiClaimExtractor(AsyncClaimExtractor):
                 conversation=c,
                 ai_service_description=aisd,
                 skip_evidences=skip_evidences,
+                intents_only=intents_only,
                 # TODO supporting True on this parameter is a bit tricky
                 # problem is the grammar-based decoding, which is unaware of the prefilling
                 prefill=False,

--- a/src/orbitals/claim_extractor/prompting.py
+++ b/src/orbitals/claim_extractor/prompting.py
@@ -396,6 +396,17 @@ from .modeling import Claim, ClaimExtractorInput, Extractions, ExtractionSubType
 
 LAST_MESSAGE_TAG = "LAST MESSAGE"
 
+# Stop string used by the generation backends when `intents_only` is enabled.
+# The model always emits intents before the `"claims"` key, so stopping as soon
+# as the claims key would begin truncates generation right after the intents are
+# complete. `"` characters inside JSON string values are escaped, so this token
+# only ever appears as the claims object key.
+CLAIMS_STOP_STRING = '"claims":'
+# Marker used to truncate generated text during parsing. vLLM excludes the stop
+# string from its output while HF's `stop_strings` includes it, so we split on
+# the (shorter) key marker to normalize both cases before repairing the JSON.
+_CLAIMS_SPLIT_MARKER = '"claims"'
+
 
 class ExtractionsResponseModel(BaseModel):
     extractions: Extractions
@@ -456,6 +467,73 @@ def validate_extractions_response(
     if isinstance(validated_obj, NoEvidenceExtractionsResponseModel):
         return validated_obj.to_extractions_response()
     return validated_obj
+
+
+def _balance_truncated_json(text: str) -> str:
+    """Close any structures left open in a truncated JSON fragment.
+
+    Scans the string while tracking whether we are inside a string literal (and
+    escape sequences) and appends the minimal `"`, `]` and `}` needed to balance
+    the open brackets. A dangling trailing comma is stripped first.
+    """
+    s = text.rstrip()
+    if s.endswith(","):
+        s = s[:-1].rstrip()
+
+    stack: list[str] = []
+    in_str = False
+    escaped = False
+    for ch in s:
+        if in_str:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch in "{[":
+            stack.append(ch)
+        elif ch == "}":
+            if stack and stack[-1] == "{":
+                stack.pop()
+        elif ch == "]":
+            if stack and stack[-1] == "[":
+                stack.pop()
+
+    closer = '"' if in_str else ""
+    for opener in reversed(stack):
+        closer += "}" if opener == "{" else "]"
+    return s + closer
+
+
+def parse_intents_only_output(text: str) -> Extractions:
+    """Parse the (truncated) output of an ``intents_only`` generation.
+
+    Generation is stopped at the ``"claims"`` boundary, so the raw text is an
+    incomplete JSON object containing only the intents. We strip code fences,
+    truncate at the claims marker (handles backends that do or do not include
+    the stop string in their output), repair the truncated JSON, and return an
+    :class:`Extractions` with the parsed intents and an empty claims list.
+    """
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        stripped = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+
+    stripped = stripped.split(_CLAIMS_SPLIT_MARKER, 1)[0]
+
+    try:
+        data = json.loads(_balance_truncated_json(stripped))
+        inner = data["extractions"] if isinstance(data, dict) else data
+        return Extractions(
+            intents=[Intent.model_validate(i) for i in inner.get("intents", [])],
+            claims=[],
+        )
+    except Exception:
+        return Extractions()
 
 
 def dumps_ai_service_description(

--- a/src/orbitals/claim_extractor/serving/main.py
+++ b/src/orbitals/claim_extractor/serving/main.py
@@ -27,6 +27,7 @@ async def lifespan(app: FastAPI):
         backend="vllm-api",
         model=os.environ["CLAIM_EXTRACTOR_VLLM_MODEL"],
         skip_evidences=os.environ.get("CLAIM_EXTRACTOR_SKIP_EVIDENCES", "1") == "1",
+        intents_only=os.environ.get("CLAIM_EXTRACTOR_INTENTS_ONLY", "0") == "1",
         vllm_serving_url=os.environ["CLAIM_EXTRACTOR_VLLM_SERVING_URL"],
         temperature=float(os.environ.get("CLAIM_EXTRACTOR_TEMPERATURE", "0.7")),
         frequency_penalty=float(
@@ -94,6 +95,7 @@ async def extract(
         str | AIServiceDescription | None, Body()
     ] = None,
     skip_evidences: Annotated[bool | None, Body()] = None,
+    intents_only: Annotated[bool | None, Body()] = None,
     model: Annotated[str | None, Body()] = None,
 ) -> ClaimExtractorResponse:
     global claim_extractor
@@ -103,6 +105,7 @@ async def extract(
         conversation,
         ai_service_description=ai_service_description,
         skip_evidences=skip_evidences,
+        intents_only=intents_only,
         model=model,
     )
     end_time = time.time()
@@ -124,6 +127,7 @@ async def batch_extract(
     ai_service_description: str | AIServiceDescription | None = Body(None),
     ai_service_descriptions: list[str] | list[AIServiceDescription] | None = Body(None),
     skip_evidences: Annotated[bool | None, Body()] = None,
+    intents_only: Annotated[bool | None, Body()] = None,
     model: Annotated[str | None, Body()] = None,
 ) -> list[ClaimExtractorResponse]:
     global claim_extractor
@@ -157,6 +161,7 @@ async def batch_extract(
             conversation,
             ai_service_description=description,
             skip_evidences=skip_evidences,
+            intents_only=intents_only,
             model=model,
         )
         end_time = time.time()
@@ -185,6 +190,7 @@ async def extract_conversation(
         str | AIServiceDescription | None, Body()
     ] = None,
     skip_evidences: Annotated[bool | None, Body()] = None,
+    intents_only: Annotated[bool | None, Body()] = None,
     model: Annotated[str | None, Body()] = None,
 ) -> ConversationClaimExtractorResponse:
     global claim_extractor
@@ -208,6 +214,7 @@ async def extract_conversation(
         prefixes,
         ai_service_description=ai_service_description,
         skip_evidences=skip_evidences,
+        intents_only=intents_only,
         model=model,
     )
     end_time = time.time()

--- a/tests/test_claim_extractor.py
+++ b/tests/test_claim_extractor.py
@@ -15,8 +15,10 @@ from orbitals.claim_extractor.extractors.base import MODEL_MAPPING
 from orbitals.claim_extractor.extractors.vllm import _USE_DEFAULT_SPECULATIVE_CONFIG
 from orbitals.claim_extractor.modeling import ClaimExtractorOutput, Extractions
 from orbitals.claim_extractor.prompting import (
+    CLAIMS_STOP_STRING,
     NoEvidenceExtractionsResponseModel,
     convert_to_conversation,
+    parse_intents_only_output,
     prepare_messages,
     validate_extractions_response,
 )
@@ -92,6 +94,78 @@ def test_get_extractions_response_model_uses_no_evidence_schema():
     converted = validated.to_extractions_response()
 
     assert isinstance(converted.extractions, Extractions)
+
+
+def test_parse_intents_only_handles_vllm_style_output_stop_excluded():
+    # vLLM excludes the stop string from output, leaving a dangling comma.
+    text = (
+        '{"extractions": {"intents": '
+        '[{"content": "The user wants package tracking."}], '
+    )
+
+    extractions = parse_intents_only_output(text)
+
+    assert [i.content for i in extractions.intents] == [
+        "The user wants package tracking."
+    ]
+    assert extractions.claims == []
+
+
+def test_parse_intents_only_handles_hf_style_output_stop_included():
+    # HF's stop_strings includes the stop string in the decoded text.
+    text = (
+        '{"extractions": {"intents": '
+        '[{"content": "The user wants package tracking."}], '
+        + CLAIMS_STOP_STRING
+    )
+
+    extractions = parse_intents_only_output(text)
+
+    assert [i.content for i in extractions.intents] == [
+        "The user wants package tracking."
+    ]
+    assert extractions.claims == []
+
+
+def test_parse_intents_only_keeps_evidences_when_present():
+    text = (
+        '{"extractions": {"intents": '
+        '[{"evidences": ["track my package"], '
+        '"content": "The user wants package tracking."}], '
+    )
+
+    extractions = parse_intents_only_output(text)
+
+    assert extractions.intents[0].evidences == ["track my package"]
+    assert extractions.claims == []
+
+
+def test_parse_intents_only_handles_empty_intents():
+    text = '{"extractions": {"intents": [], '
+
+    extractions = parse_intents_only_output(text)
+
+    assert extractions.intents == []
+    assert extractions.claims == []
+
+
+def test_parse_intents_only_returns_empty_on_malformed_output():
+    extractions = parse_intents_only_output("this is not json at all")
+
+    assert extractions.intents == []
+    assert extractions.claims == []
+
+
+def test_parse_intents_only_strips_code_fences():
+    text = (
+        "```json\n"
+        '{"extractions": {"intents": [{"content": "The user wants a refund."}], '
+    )
+
+    extractions = parse_intents_only_output(text)
+
+    assert [i.content for i in extractions.intents] == ["The user wants a refund."]
+    assert extractions.claims == []
 
 
 def test_prepare_messages_serializes_structured_ai_service_description():
@@ -183,6 +257,34 @@ def test_claim_extractor_pipeline_allows_per_call_skip_evidences_override(monkey
     assert preprocess_kwargs == {"skip_evidences": False}
 
 
+def test_claim_extractor_pipeline_forwards_intents_only_constructor_default(monkeypatch):
+    _install_fake_pipeline_modules(monkeypatch)
+    module = importlib.reload(importlib.import_module("hf_pipeline.claim_extractor"))
+    pipeline = module.ClaimExtractionPipeline(
+        model=object(),
+        tokenizer=types.SimpleNamespace(pad_token="</s>"),
+        intents_only=True,
+    )
+
+    _, forward_kwargs, _ = pipeline._sanitize_parameters()
+
+    assert forward_kwargs == {"intents_only": True}
+
+
+def test_claim_extractor_pipeline_allows_per_call_intents_only_override(monkeypatch):
+    _install_fake_pipeline_modules(monkeypatch)
+    module = importlib.reload(importlib.import_module("hf_pipeline.claim_extractor"))
+    pipeline = module.ClaimExtractionPipeline(
+        model=object(),
+        tokenizer=types.SimpleNamespace(pad_token="</s>"),
+        intents_only=False,
+    )
+
+    _, forward_kwargs, _ = pipeline._sanitize_parameters(intents_only=True)
+
+    assert forward_kwargs == {"intents_only": True}
+
+
 def _extract_response_payload(
     *,
     usage: dict[str, int] | None = None,
@@ -226,6 +328,28 @@ def test_claim_extractor_api_serializes_structured_ai_service_description(
         "principles": None,
         "website_url": None,
     }
+
+
+def test_claim_extractor_api_includes_intents_only_in_payload(
+    mocked_claim_extractor_post,
+):
+    ce = ClaimExtractor(backend="api", api_url="http://example.com")
+
+    ce.extract("hi", intents_only=True)
+
+    body = mocked_claim_extractor_post.call_args.kwargs["json"]
+    assert body["intents_only"] is True
+
+
+def test_claim_extractor_api_uses_constructor_intents_only_default(
+    mocked_claim_extractor_post,
+):
+    ce = ClaimExtractor(backend="api", api_url="http://example.com", intents_only=True)
+
+    ce.extract("hi")
+
+    body = mocked_claim_extractor_post.call_args.kwargs["json"]
+    assert body["intents_only"] is True
 
 
 def test_claim_extractor_api_does_not_mutate_caller_headers(


### PR DESCRIPTION
## What & Why
Adds an `intents_only` parameter to every claim-extractor backend (`hf`, `vllm`, `vllm-api`, `api`). When enabled, generation **stops as soon as the model finishes the intents** — right before the `"claims"` key — so the (often much larger) claims section is never generated. This is a real stopping criterion at generation time, not a post-hoc filter, so callers who only need user intents get faster, cheaper extraction.

## Changes
- **`prompting.py`** — new `CLAIMS_STOP_STRING` constant and `parse_intents_only_output()`: strips code fences, truncates at the claims marker (normalizing backends that include the stop string, e.g. HF, vs. those that exclude it, e.g. vLLM), repairs the truncated JSON with a string-aware bracket balancer, and returns an `Extractions` with an empty `claims` list (lenient empty fallback on failure).
- **`extractors/vllm.py`** — `VLLMClaimExtractor` clones `SamplingParams` with `stop=[...]`; `AsyncVLLMApiClaimExtractor` adds `"stop"` to the `/v1/completions` body. Both branch to the intents-only parser.
- **`extractors/hf.py`** + **`hf_pipeline/claim_extractor.py`** — the pipeline passes `stop_strings` + `tokenizer` to `generate()`; the extractor branches parsing.
- **`extractors/api.py`** — `intents_only` added to request builders, constructors, and per-call overrides (sync + async).
- **`extractors/base.py`** — threaded through `extract`/`batch_extract` and added to the typed `__new__` overloads.
- **`serving/main.py`** + **`cli/serve.py`** — `CLAIM_EXTRACTOR_INTENTS_ONLY` env var, `intents_only` body param on all three endpoints, and a matching `--intents-only` serve flag.
- **`README.claim-extractor.md`** — new "Intents only" section plus serving notes.

`intents_only` mirrors the existing `skip_evidences` pattern: a constructor default (`False`) plus a per-call override.

## Testing
- `uv run pytest` → **127 passed** (9 new tests: parser for vLLM/HF/evidences/empty/malformed/fenced output, API payload propagation, pipeline parameter forwarding).
- `uv run ty check` → all checks passed.
- Verified end-to-end on the real `principled-intelligence/claim-extractor-2B-q-2605` model via vLLM: the same input produced an identical intent in both modes, with 2 claims when `intents_only=False` and **0 claims** when `intents_only=True`.

## Notes for Reviewer
The `hf` backend loads its pipeline via `trust_remote_code` from the HF model repo, **not** the local `src/hf_pipeline/claim_extractor.py`. This PR keeps the repo source in sync and makes the unit tests pass, but for the `hf` backend to actually use `intents_only` in production, the updated pipeline must also be pushed to the `principled-intelligence/claim-extractor-*` model repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)