### PR TITLE
feat(scope-guard-v2): add ScopeGuard V2 orbital

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Orbitals currently provides the following guardrail modules:
 | Guardrail | Description | Hosting Options |
 |:----------|:------------|:----------------|
 | **[ScopeGuard](README.scope-guard.md)** | Classifies user queries against AI assistant specifications to detect out-of-scope requests, policy violations, and chit-chat | Self-hosted / Cloud hosting |
+| **[ScopeGuard V2](README.scope-guard-v2.md)** | Next-generation ScopeGuard with structured AI service descriptions and new scope classes for predefined answers and human escalation, plus reasoning and suggested responses | Cloud hosting (API-only for now; models currently private) |
 | **[ClaimExtractor](README.claim-extractor.md)** | Extracts atomic, decontextualized claims (Factoid, Capability, User Assertion, Unverifiable) and user intents from a conversation, with optional verbatim evidences — a building block for fact-checking, hallucination detection, intent routing, and response auditing | Self-hosted / Cloud hosting |
 | 🚀 *Coming Soon* | More guardrails are on the way — stay tuned for updates! | — |
 
@@ -87,6 +88,7 @@ Orbitals currently provides the following guardrail modules:
 For detailed documentation, including installation instructions, usage guides, and API references, please visit the Orbitals Documentation.
 
 - [ScopeGuard Documentation](README.scope-guard.md)
+- [ScopeGuard V2 Documentation](README.scope-guard-v2.md)
 - [ClaimExtractor Documentation](README.claim-extractor.md)
 
 ### FAQ

--- a/README.scope-guard-v2.md
+++ b/README.scope-guard-v2.md
@@ -1,0 +1,236 @@
+<div align="left">
+    <h1>
+        <strong>ScopeGuard V2</strong>
+    </h1>
+</div>
+
+ScopeGuard V2 is the next generation of [ScopeGuard](README.scope-guard.md). Given the specifications of an AI service and a conversation, `scope-guard-v2` classifies the last user message into one of the following seven classes:
+
+* **Directly Supported**: The query is clearly within the AI service's capabilities.
+* **Potentially Supported**: The query could plausibly be handled by the AI service.
+* **Predefined Answer**: The query matches a predefined scenario or FAQ with a specific, pre-written response.
+* **Human Oversight**: The query requires human oversight, judgment, or expertise (e.g., it meets an escalation criterion).
+* **Out of Scope**: The query is outside the AI service's defined role.
+* **Restricted**: The query cannot be handled due to a specific constraint.
+* **Chit Chat**: The query is a social interaction not related to the AI service's function.
+
+On top of the classification, ScopeGuard V2 returns:
+
+* **`evidences`**: verbatim spans from the AI service description supporting the decision (optional, can be skipped for lower latency)
+* **`reasoning`**: a short explanation of why the class was chosen
+* **`suggested_response`**: a ready-to-use response for the user when the query should not be processed (e.g., for Predefined Answer, Human Oversight, Out of Scope, Restricted, or Chit Chat)
+
+> [!IMPORTANT]
+> **Model availability**: The ScopeGuard V2 models are currently **private** and accessible **only via API** through Principled Intelligence's hosted service. An open-weight release will follow.
+> Want access? Contact us at [orbitals@principled-intelligence.com](mailto:orbitals@principled-intelligence.com).
+
+## Quickstart
+
+Since ScopeGuard V2 is API-only for the moment, plain `orbitals` is all you need:
+
+```bash
+pip install orbitals
+```
+
+Then:
+
+```python
+from orbitals.scope_guard_v2 import ScopeGuardV2
+
+sg = ScopeGuardV2(
+    backend="api",
+    api_key="principled_1234",  # replace with your actual API key
+)
+
+ai_service_description = """
+You are a virtual assistant for a parcel delivery service.
+You can only answer questions about package tracking.
+Never respond to requests for refunds.
+"""
+
+user_query = "If the package hasn't arrived by tomorrow, can I get my money back?"
+result = sg.validate(user_query, ai_service_description=ai_service_description)
+
+print(f"Scope: {result.scope_class.value}")
+print(f"Reasoning: {result.reasoning}")
+if result.suggested_response:
+    print(f"Suggested response: {result.suggested_response}")
+
+# Scope: Restricted
+# Reasoning: The request asks for a refund, which the service description explicitly forbids.
+# Suggested response: I'm sorry, but I cannot help with refund requests. I can assist you with package tracking.
+```
+
+An asynchronous client is also available:
+
+```python
+from orbitals.scope_guard_v2 import AsyncScopeGuardV2
+
+sg = AsyncScopeGuardV2(
+    backend="api",
+    api_key="principled_1234",  # replace with your actual API key
+)
+
+result = await sg.validate(user_query, ai_service_description=ai_service_description)
+```
+
+## Usage
+
+### Scope Classes
+
+The possible scope classes returned by `scope-guard-v2` are:
+
+```python
+from orbitals.scope_guard_v2 import ScopeClass
+
+print(ScopeClass.DIRECTLY_SUPPORTED.value)    # "Directly Supported"
+print(ScopeClass.POTENTIALLY_SUPPORTED.value) # "Potentially Supported"
+print(ScopeClass.PREDEFINED_ANSWER.value)     # "Predefined Answer"
+print(ScopeClass.HUMAN_OVERSIGHT.value)       # "Human Oversight"
+print(ScopeClass.OUT_OF_SCOPE.value)          # "Out of Scope"
+print(ScopeClass.RESTRICTED.value)            # "Restricted"
+print(ScopeClass.CHIT_CHAT.value)             # "Chit Chat"
+```
+
+For example, you can check the scope class of a validation result as follows:
+
+```python
+result = sg.validate(user_query, ai_service_description=ai_service_description)
+
+# Using the Enum member:
+if result.scope_class == ScopeClass.RESTRICTED:
+    print("The user query is restricted.")
+
+# Or using the string value:
+if result.scope_class.value == "Restricted":
+    print("The user query is restricted.")
+```
+
+### Structured AI Service Description
+
+While the AI service description can still be provided as a plain string, ScopeGuard V2 introduces `orbitals.types.AIServiceDescriptionV2`, a structured description that drives the new scope classes (**strongly recommended approach**):
+
+```python
+from orbitals.types import AIServiceDescriptionV2, PredefinedResponse
+
+ai_service_description = AIServiceDescriptionV2(
+    identity_role="Virtual assistant for a parcel delivery service.",
+    context="Operates for an e-commerce logistics company; users are customers tracking their orders.",
+    knowledge_scope="Package tracking, delivery times, and shipment statuses.",
+    functionalities=[
+        "Track packages by tracking number",
+        "Provide expected delivery dates",
+    ],
+    constraints=[
+        "Never respond to requests for refunds",
+    ],
+    predefined_responses=[
+        PredefinedResponse(
+            trigger="user asks for the support phone number",
+            response="You can reach our support team at +1-800-555-0100.",
+        ),
+    ],
+    escalation_criteria=[
+        "The user reports a lost or damaged package",
+        "The user threatens legal action",
+    ],
+    response_guidelines="Be concise and friendly.",
+)
+
+result = sg.validate(user_query, ai_service_description=ai_service_description)
+```
+
+* **`predefined_responses`** powers the **Predefined Answer** class: when a trigger matches, the suggested response contains the pre-written answer.
+* **`escalation_criteria`** powers the **Human Oversight** class: when a criterion is met, the query is flagged for human review.
+* **`constraints`** powers the **Restricted** class.
+
+### Input Formats
+
+The `validate` method accepts the same input formats as ScopeGuard V1:
+
+```python
+# User query as a string
+result = sg.validate(
+    "When is my package scheduled to arrive?",
+    ai_service_description=ai_service_description,
+)
+
+# User query as a dictionary (OpenAI's API Message)
+result = sg.validate(
+    {"role": "user", "content": "When is my package scheduled to arrive?"},
+    ai_service_description=ai_service_description,
+)
+
+# Conversation as a list of dictionaries
+result = sg.validate(
+    [
+        {"role": "user", "content": "I ordered a package, tracking number 1234567890"},
+        {"role": "assistant", "content": "Great, the package is in transit. What would you like to know?"},
+        {"role": "user", "content": "If it doesn't arrive tomorrow, can I get a refund"},
+    ],
+    ai_service_description=ai_service_description,
+)
+```
+
+With multi-turn conversations, the scope decision is computed exclusively for **the final user message**, with earlier turns considered only as conversational context.
+
+### Skipping Evidences
+
+If you don't need the supporting evidences, you can skip them to reduce latency and token usage, either per guard or per call:
+
+```python
+sg = ScopeGuardV2(backend="api", api_key="principled_1234", skip_evidences=True)
+
+# or per call
+result = sg.validate(
+    user_query,
+    ai_service_description=ai_service_description,
+    skip_evidences=True,
+)
+```
+
+### Default Safety Principles
+
+Like V1, ScopeGuard V2 can optionally add a built-in set of general safety restrictions to the AI service description before classification. When the description is an `AIServiceDescriptionV2`, they are appended to its `constraints`; service-specific rules are overridden on conflict.
+
+```python
+sg = ScopeGuardV2(
+    backend="api",
+    api_key="principled_1234",
+    include_default_safety_principles=True,
+)
+
+# or per call
+result = sg.validate(
+    user_query,
+    ai_service_description=ai_service_description,
+    include_default_safety_principles=True,
+)
+```
+
+### Batch Processing
+
+You can process multiple conversations at once using `batch_validate`, with either a single shared AI service description or one per conversation:
+
+```python
+queries = [
+    "If the package hasn't arrived by tomorrow, can I get my money back?",
+    "When is the package expected to be delivered?",
+]
+
+# Single AI Service Description
+results = sg.batch_validate(queries, ai_service_description=ai_service_description)
+
+# Multiple AI Service Descriptions (one per conversation)
+results = sg.batch_validate(queries, ai_service_descriptions=[desc_1, desc_2])
+```
+
+## Self-hosting
+
+The library already ships the `vllm`, `hf`, and serving backends for ScopeGuard V2 (`orbitals scope-guard-v2 serve`), but they require access to the model weights, which are **private for the moment**. Once the open-weight models are released, self-hosting will work exactly as it does for [ScopeGuard V1](README.scope-guard.md#serving-scopeguard-on-premise-or-on-your-infrastructure).
+
+If you need on-premise deployment earlier, contact us at [orbitals@principled-intelligence.com](mailto:orbitals@principled-intelligence.com).
+
+## License
+
+This project is licensed under the Apache 2.0 License.

--- a/src/hf_pipeline/scope_guard_v2.py
+++ b/src/hf_pipeline/scope_guard_v2.py
@@ -1,0 +1,119 @@
+import torch
+import transformers
+from transformers import Pipeline
+
+try:
+    import orbitals.scope_guard_v2
+    import orbitals.scope_guard_v2.modeling
+    import orbitals.scope_guard_v2.prompting
+    import orbitals.types
+except ModuleNotFoundError:
+    raise ImportError(
+        "orbitals.scope_guard_v2 module not found. Please install it: `pip install orbitals`"
+    )
+
+
+class ScopeGuardV2Pipeline(Pipeline):
+    def __init__(
+        self,
+        model,
+        tokenizer=None,
+        skip_evidences: bool = False,
+        max_new_tokens: int = 1024,
+        do_sample: bool = False,
+        **kwargs,
+    ):
+        if tokenizer is None and isinstance(model, str):
+            tokenizer = transformers.AutoTokenizer.from_pretrained(model)
+        elif isinstance(tokenizer, str):
+            tokenizer = transformers.AutoTokenizer.from_pretrained(tokenizer)
+
+        if isinstance(model, str):
+            model = transformers.AutoModelForCausalLM.from_pretrained(
+                model, dtype="auto", device_map="auto"
+            )
+
+        if tokenizer is not None:
+            tokenizer.padding_side = "left"
+            if tokenizer.pad_token is None:
+                tokenizer.pad_token = tokenizer.eos_token
+
+        self.skip_evidences = skip_evidences
+        self.max_new_tokens = max_new_tokens
+        self.do_sample = do_sample
+
+        super().__init__(model, tokenizer, **kwargs)
+
+    def _sanitize_parameters(self, **kwargs):
+        preprocess_kwargs = {}
+        if "skip_evidences" in kwargs or self.skip_evidences:
+            preprocess_kwargs["skip_evidences"] = kwargs.get(
+                "skip_evidences", self.skip_evidences
+            )
+
+        return (
+            preprocess_kwargs,
+            {},
+            {},
+        )
+
+    def preprocess(
+        self,
+        inputs: tuple[
+            orbitals.scope_guard_v2.modeling.ScopeGuardV2Input,
+            str | orbitals.types.AIServiceDescriptionV2,
+        ],
+        skip_evidences: bool = False,
+    ):
+        conversation, ai_service_description = inputs
+
+        model_messages = orbitals.scope_guard_v2.prompting.prepare_input_messages(
+            conversation,
+            ai_service_description,
+            skip_evidences,
+        )
+
+        text = self.tokenizer.apply_chat_template(
+            model_messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=False,
+        )
+
+        return {"text": text}
+
+    def _forward(self, model_inputs):
+        tokenized = self.tokenizer(
+            model_inputs["text"],
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+        ).to(self.device)
+
+        with torch.inference_mode():
+            outputs = self.model.generate(
+                **tokenized,
+                max_new_tokens=self.max_new_tokens,
+                do_sample=self.do_sample,
+                eos_token_id=self.tokenizer.eos_token_id,
+                pad_token_id=self.tokenizer.pad_token_id,
+            )
+        return {
+            "output_ids": outputs,
+            "input_ids": tokenized["input_ids"],
+        }
+
+    def postprocess(self, model_outputs):
+        output_ids = model_outputs["output_ids"]
+        input_ids = model_outputs["input_ids"]
+
+        results = []
+        for i in range(output_ids.shape[0]):
+            generated_ids = output_ids[i][input_ids.shape[1] :]
+            generated_output = self.tokenizer.decode(
+                generated_ids,
+                skip_special_tokens=True,
+            )
+            results.append({"generated_text": generated_output})
+
+        return results

--- a/src/orbitals/cli/main.py
+++ b/src/orbitals/cli/main.py
@@ -2,10 +2,12 @@ import typer
 
 from ..claim_extractor.cli.main import app as claim_extractor_app
 from ..scope_guard.cli.main import app as scope_app
+from ..scope_guard_v2.cli.main import app as scope_v2_app
 
 app = typer.Typer()
 
 app.add_typer(scope_app, name="scope-guard")
+app.add_typer(scope_v2_app, name="scope-guard-v2")
 app.add_typer(claim_extractor_app, name="claim-extractor")
 
 

--- a/src/orbitals/scope_guard_v2/__init__.py
+++ b/src/orbitals/scope_guard_v2/__init__.py
@@ -1,0 +1,15 @@
+from .guards import AsyncScopeGuardV2, ScopeGuardV2
+from .modeling import ScopeClass, ScopeGuardV2Output
+from .safety_principles import (
+    ADDITIONAL_SAFETY_RULES,
+    augment_with_default_safety_principles_v2,
+)
+
+__all__ = [
+    "ADDITIONAL_SAFETY_RULES",
+    "AsyncScopeGuardV2",
+    "ScopeClass",
+    "ScopeGuardV2",
+    "ScopeGuardV2Output",
+    "augment_with_default_safety_principles_v2",
+]

--- a/src/orbitals/scope_guard_v2/cli/convert_default_model_name.py
+++ b/src/orbitals/scope_guard_v2/cli/convert_default_model_name.py
@@ -1,10 +1,8 @@
 import typer
 
-from orbitals.scope_guard_v2 import ScopeGuardV2
-
 app = typer.Typer()
 
 
 @app.command("convert-default-model-name")
 def convert_default_model_name(model_name: str = typer.Argument(..., help="The model name")):
-    print(ScopeGuardV2.maybe_map_model(model_name))
+    print(model_name)

--- a/src/orbitals/scope_guard_v2/cli/convert_default_model_name.py
+++ b/src/orbitals/scope_guard_v2/cli/convert_default_model_name.py
@@ -1,0 +1,10 @@
+import typer
+
+from orbitals.scope_guard_v2 import ScopeGuardV2
+
+app = typer.Typer()
+
+
+@app.command("convert-default-model-name")
+def convert_default_model_name(model_name: str = typer.Argument(..., help="The model name")):
+    print(ScopeGuardV2.maybe_map_model(model_name))

--- a/src/orbitals/scope_guard_v2/cli/main.py
+++ b/src/orbitals/scope_guard_v2/cli/main.py
@@ -1,0 +1,16 @@
+import typer
+
+from . import convert_default_model_name, serve
+
+app = typer.Typer()
+
+app.add_typer(serve.app)
+app.add_typer(convert_default_model_name.app)
+
+
+def main():
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/orbitals/scope_guard_v2/cli/serve.py
+++ b/src/orbitals/scope_guard_v2/cli/serve.py
@@ -1,0 +1,131 @@
+import logging
+import os
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+import typer
+import uvicorn
+
+from orbitals.scope_guard_v2 import ScopeGuardV2
+
+app = typer.Typer()
+
+
+def setup_fastapi_logging():
+    """Configure logging for the FastAPI server."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[FastAPI] %(levelname)s %(asctime)s %(name)s:%(lineno)d] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
+
+
+@app.command("serve")
+def serve(
+    vllm_model: str = typer.Argument(..., help="The model used for vLLM serving"),
+    skip_evidences: bool = typer.Option(False, help="Whether to skip evidences"),
+    port: int = typer.Option(
+        8000, "-p", "--port", help="The port to use for the server"
+    ),
+    host: str = typer.Option(
+        "0.0.0.0", "-h", "--host", help="The host to use for the server"
+    ),
+    vllm_port: int = typer.Option(8001, help="The port to use for the vLLM server"),
+    vllm_max_model_len: int = typer.Option(
+        30_000, help="Maximum model length for vLLM"
+    ),
+    vllm_max_num_seqs: int = typer.Option(
+        2, help="Maximum number of sequences for vLLM"
+    ),
+    vllm_gpu_memory_utilization: float = typer.Option(
+        0.9, help="GPU memory utilization for vLLM"
+    ),
+    vllm_extra_args: str | None = typer.Option(
+        None, help="Extra arguments to pass to the vLLM server"
+    ),
+):
+    vllm_model = ScopeGuardV2.maybe_map_model(vllm_model)
+
+    os.environ["SCOPE_GUARD_V2_VLLM_MODEL"] = vllm_model
+    os.environ["SCOPE_GUARD_V2_VLLM_SERVING_URL"] = f"http://localhost:{vllm_port}"
+    os.environ["SCOPE_GUARD_V2_SKIP_EVIDENCES"] = (
+        str(1) if skip_evidences else str(0)
+    )
+
+    vllm_logging_config = (
+        Path(__file__).parent.parent / "serving" / "vllm_logging_config.json"
+    )
+    os.environ["VLLM_LOGGING_CONFIG_PATH"] = str(vllm_logging_config)
+
+    vllm_cmd = [
+        "vllm",
+        "serve",
+        vllm_model,
+        "--max-model-len",
+        str(vllm_max_model_len),
+        "--max-num-seqs",
+        str(vllm_max_num_seqs),
+        "--port",
+        str(vllm_port),
+        "--gpu-memory-utilization",
+        str(vllm_gpu_memory_utilization),
+        *(shlex.split(vllm_extra_args) if vllm_extra_args is not None else []),
+    ]
+
+    typer.echo(f"Starting vLLM server: {' '.join(vllm_cmd)}")
+    vllm_process = subprocess.Popen(vllm_cmd, stdout=sys.stdout, stderr=sys.stderr)
+
+    typer.echo(
+        f"Waiting for vLLM server to be ready at http://localhost:{vllm_port}..."
+    )
+    max_retries = 60
+    retry_delay = 5
+
+    for i in range(max_retries):
+        try:
+            response = httpx.get(f"http://localhost:{vllm_port}/health", timeout=2.0)
+            if response.status_code == 200:
+                typer.echo("vLLM server is ready!")
+                break
+        except (httpx.RequestError, httpx.HTTPError):
+            if i < max_retries - 1:
+                typer.echo(f"vLLM server not ready yet, retrying in {retry_delay}s...")
+                time.sleep(retry_delay)
+            else:
+                typer.echo("vLLM server failed to start in time", err=True)
+                vllm_process.terminate()
+                vllm_process.wait()
+                raise typer.Exit(code=1)
+
+    setup_fastapi_logging()
+    typer.echo(f"Starting FastAPI server on {host}:{port}")
+
+    log_config = uvicorn.config.LOGGING_CONFIG  # type: ignore[attr-defined]
+    log_config["formatters"]["default"]["fmt"] = (
+        "[FastAPI] %(levelprefix)s %(asctime)s %(name)s] %(message)s"
+    )
+    log_config["formatters"]["default"]["datefmt"] = "%Y-%m-%d %H:%M:%S"
+    log_config["formatters"]["access"]["fmt"] = (
+        "[FastAPI] %(levelprefix)s %(asctime)s %(client_addr)s - "
+        '"%(request_line)s" %(status_code)s'
+    )
+    log_config["formatters"]["access"]["datefmt"] = "%Y-%m-%d %H:%M:%S"
+
+    try:
+        uvicorn.run(
+            "orbitals.scope_guard_v2.serving.main:app",
+            host=host,
+            port=port,
+            log_config=log_config,
+            log_level="info",
+        )
+    finally:
+        typer.echo("Shutting down vLLM server...")
+        vllm_process.terminate()
+        vllm_process.wait(timeout=10)

--- a/src/orbitals/scope_guard_v2/cli/serve.py
+++ b/src/orbitals/scope_guard_v2/cli/serve.py
@@ -10,8 +10,6 @@ import httpx
 import typer
 import uvicorn
 
-from orbitals.scope_guard_v2 import ScopeGuardV2
-
 app = typer.Typer()
 
 
@@ -50,8 +48,6 @@ def serve(
         None, help="Extra arguments to pass to the vLLM server"
     ),
 ):
-    vllm_model = ScopeGuardV2.maybe_map_model(vllm_model)
-
     os.environ["SCOPE_GUARD_V2_VLLM_MODEL"] = vllm_model
     os.environ["SCOPE_GUARD_V2_VLLM_SERVING_URL"] = f"http://localhost:{vllm_port}"
     os.environ["SCOPE_GUARD_V2_SKIP_EVIDENCES"] = (

--- a/src/orbitals/scope_guard_v2/guards/__init__.py
+++ b/src/orbitals/scope_guard_v2/guards/__init__.py
@@ -1,0 +1,14 @@
+from .api import APIScopeGuardV2, AsyncAPIScopeGuardV2
+from .base import AsyncScopeGuardV2, ScopeGuardV2
+from .hf import HuggingFaceScopeGuardV2
+from .vllm import AsyncVLLMApiScopeGuardV2, VLLMScopeGuardV2
+
+__all__ = [
+    "AsyncScopeGuardV2",
+    "ScopeGuardV2",
+    "HuggingFaceScopeGuardV2",
+    "VLLMScopeGuardV2",
+    "APIScopeGuardV2",
+    "AsyncAPIScopeGuardV2",
+    "AsyncVLLMApiScopeGuardV2",
+]

--- a/src/orbitals/scope_guard_v2/guards/api.py
+++ b/src/orbitals/scope_guard_v2/guards/api.py
@@ -116,7 +116,7 @@ class APIScopeGuardV2(ScopeGuardV2):
             backend,
             include_default_safety_principles=include_default_safety_principles,
         )
-        self.default_model = self.maybe_map_model(model) if model is not None else None
+        self.default_model = model
         self.api_url = api_url
         self.api_key = _maybe_get_api_key(api_key, custom_headers)
         self.skip_evidences = skip_evidences
@@ -191,7 +191,7 @@ class AsyncAPIScopeGuardV2(AsyncScopeGuardV2):
             backend,
             include_default_safety_principles=include_default_safety_principles,
         )
-        self.default_model = self.maybe_map_model(model) if model is not None else None
+        self.default_model = model
         self.api_url = api_url
         self.api_key = _maybe_get_api_key(api_key, custom_headers)
         self.skip_evidences = skip_evidences

--- a/src/orbitals/scope_guard_v2/guards/api.py
+++ b/src/orbitals/scope_guard_v2/guards/api.py
@@ -1,0 +1,256 @@
+import logging
+import os
+from typing import Literal
+
+import aiohttp
+import requests
+
+from ...types import AIServiceDescriptionV2
+from ..modeling import (
+    ScopeGuardV2Input,
+    ScopeGuardV2InputTypeAdapter,
+    ScopeGuardV2Output,
+)
+from .base import AsyncScopeGuardV2, ScopeGuardV2
+
+
+def _build_request_data(
+    model: str | None,
+    conversation: ScopeGuardV2Input,
+    skip_evidences: bool,
+    ai_service_description: str | AIServiceDescriptionV2,
+) -> dict:
+    return {
+        **({"model": model} if model is not None else {}),
+        "conversation": ScopeGuardV2InputTypeAdapter.dump_python(conversation),
+        "ai_service_description": ai_service_description.model_dump()
+        if isinstance(ai_service_description, AIServiceDescriptionV2)
+        else ai_service_description,
+        "skip_evidences": skip_evidences,
+    }
+
+
+def _build_batch_request_data(
+    model: str | None,
+    conversations: list[ScopeGuardV2Input],
+    skip_evidences: bool,
+    ai_service_description: str | AIServiceDescriptionV2 | None = None,
+    ai_service_descriptions: list[str] | list[AIServiceDescriptionV2] | None = None,
+) -> dict:
+    return {
+        **({"model": model} if model is not None else {}),
+        "conversations": [
+            ScopeGuardV2InputTypeAdapter.dump_python(conversation)
+            for conversation in conversations
+        ],
+        **(
+            (
+                {"ai_service_description": ai_service_description.model_dump()}
+                if isinstance(ai_service_description, AIServiceDescriptionV2)
+                else {"ai_service_description": ai_service_description}
+            )
+            if ai_service_description is not None
+            else {}
+        ),
+        **(
+            {
+                "ai_service_descriptions": [
+                    (
+                        ad.model_dump()
+                        if isinstance(ad, AIServiceDescriptionV2)
+                        else ad
+                    )
+                    for ad in ai_service_descriptions
+                ]
+            }
+            if ai_service_descriptions is not None
+            else {}
+        ),
+        "skip_evidences": skip_evidences,
+    }
+
+
+def _maybe_get_api_key(
+    args_api_key: str | None,
+    custom_headers: dict[str, str] | None,
+) -> str | None:
+    if args_api_key is not None:
+        logging.debug("Using API key from argument")
+        return args_api_key
+
+    if custom_headers is not None and "X-API-Key" in custom_headers:
+        logging.debug("Using API key from custom headers")
+        return custom_headers.pop("X-API-Key")
+
+    api_key = os.environ.get("PRINCIPLED_API_KEY")
+    if api_key is not None:
+        logging.debug("Using API key from environment variable")
+
+    return api_key
+
+
+def _parse_output(result: dict) -> ScopeGuardV2Output:
+    return ScopeGuardV2Output(
+        scope_class=result["scope_class"],
+        evidences=result.get("evidences"),
+        reasoning=result["reasoning"],
+        suggested_response=result.get("suggested_response"),
+        model=result["model"],
+        usage=result.get("usage"),
+    )
+
+
+@ScopeGuardV2.register_guard("api")
+class APIScopeGuardV2(ScopeGuardV2):
+    def __init__(
+        self,
+        backend: Literal["api"] = "api",
+        model: str | None = None,
+        api_url: str = "http://localhost:8000",
+        api_key: str | None = None,
+        skip_evidences: bool = False,
+        custom_headers: dict[str, str] | None = None,
+        include_default_safety_principles: bool = False,
+    ):
+        super().__init__(
+            backend,
+            include_default_safety_principles=include_default_safety_principles,
+        )
+        self.default_model = self.maybe_map_model(model) if model is not None else None
+        self.api_url = api_url
+        self.api_key = _maybe_get_api_key(api_key, custom_headers)
+        self.skip_evidences = skip_evidences
+        self.custom_headers = custom_headers if custom_headers is not None else {}
+        if self.api_key is not None:
+            self.custom_headers["X-API-Key"] = self.api_key
+
+    def _validate(
+        self,
+        conversation: ScopeGuardV2Input,
+        *,
+        ai_service_description: str | AIServiceDescriptionV2,
+        skip_evidences: bool | None = None,
+        model: str | None = None,
+        **kwargs,
+    ) -> ScopeGuardV2Output:
+        response = requests.post(
+            f"{self.api_url}/orbitals/scope-guard-v2/validate",
+            json=_build_request_data(
+                model=model if model is not None else self.default_model,
+                conversation=conversation,
+                skip_evidences=skip_evidences
+                if skip_evidences is not None
+                else self.skip_evidences,
+                ai_service_description=ai_service_description,
+            ),
+            headers={**self.custom_headers, "Content-Type": "application/json"},
+        )
+        response.raise_for_status()
+        return _parse_output(response.json())
+
+    def _batch_validate(
+        self,
+        conversations: list[ScopeGuardV2Input],
+        *,
+        ai_service_description: str | AIServiceDescriptionV2 | None = None,
+        ai_service_descriptions: list[str] | list[AIServiceDescriptionV2] | None = None,
+        skip_evidences: bool | None = None,
+        model: str | None = None,
+        **kwargs,
+    ) -> list[ScopeGuardV2Output]:
+        response = requests.post(
+            f"{self.api_url}/orbitals/scope-guard-v2/batch-validate",
+            json=_build_batch_request_data(
+                model=model if model is not None else self.default_model,
+                conversations=conversations,
+                skip_evidences=skip_evidences
+                if skip_evidences is not None
+                else self.skip_evidences,
+                ai_service_description=ai_service_description,
+                ai_service_descriptions=ai_service_descriptions,
+            ),
+            headers={**self.custom_headers, "Content-Type": "application/json"},
+        )
+        response.raise_for_status()
+        return [_parse_output(result) for result in response.json()]
+
+
+@AsyncScopeGuardV2.register_guard("api")
+class AsyncAPIScopeGuardV2(AsyncScopeGuardV2):
+    def __init__(
+        self,
+        backend: Literal["api", "async-api"] = "api",
+        model: str | None = None,
+        api_url: str = "http://localhost:8000",
+        api_key: str | None = None,
+        skip_evidences: bool = False,
+        custom_headers: dict[str, str] | None = None,
+        include_default_safety_principles: bool = False,
+    ):
+        super().__init__(
+            backend,
+            include_default_safety_principles=include_default_safety_principles,
+        )
+        self.default_model = self.maybe_map_model(model) if model is not None else None
+        self.api_url = api_url
+        self.api_key = _maybe_get_api_key(api_key, custom_headers)
+        self.skip_evidences = skip_evidences
+        self.custom_headers = custom_headers if custom_headers is not None else {}
+        if self.api_key is not None:
+            self.custom_headers["X-API-Key"] = self.api_key
+
+    async def _validate(
+        self,
+        conversation: ScopeGuardV2Input,
+        *,
+        ai_service_description: str | AIServiceDescriptionV2,
+        skip_evidences: bool | None = None,
+        model: str | None = None,
+        **kwargs,
+    ) -> ScopeGuardV2Output:
+        async with aiohttp.ClientSession() as session:
+            response = await session.post(
+                f"{self.api_url}/orbitals/scope-guard-v2/validate",
+                json=_build_request_data(
+                    model=model if model is not None else self.default_model,
+                    conversation=conversation,
+                    skip_evidences=skip_evidences
+                    if skip_evidences is not None
+                    else self.skip_evidences,
+                    ai_service_description=ai_service_description,
+                ),
+                headers={**self.custom_headers, "Content-Type": "application/json"},
+            )
+            response.raise_for_status()
+            response_data = await response.json()
+
+        return _parse_output(response_data)
+
+    async def _batch_validate(
+        self,
+        conversations: list[ScopeGuardV2Input],
+        *,
+        ai_service_description: str | AIServiceDescriptionV2 | None = None,
+        ai_service_descriptions: list[str] | list[AIServiceDescriptionV2] | None = None,
+        skip_evidences: bool | None = None,
+        model: str | None = None,
+        **kwargs,
+    ) -> list[ScopeGuardV2Output]:
+        async with aiohttp.ClientSession() as session:
+            response = await session.post(
+                f"{self.api_url}/orbitals/scope-guard-v2/batch-validate",
+                json=_build_batch_request_data(
+                    model=model if model is not None else self.default_model,
+                    conversations=conversations,
+                    skip_evidences=skip_evidences
+                    if skip_evidences is not None
+                    else self.skip_evidences,
+                    ai_service_description=ai_service_description,
+                    ai_service_descriptions=ai_service_descriptions,
+                ),
+                headers={**self.custom_headers, "Content-Type": "application/json"},
+            )
+            response.raise_for_status()
+            response_data = await response.json()
+
+        return [_parse_output(result) for result in response_data]

--- a/src/orbitals/scope_guard_v2/guards/base.py
+++ b/src/orbitals/scope_guard_v2/guards/base.py
@@ -42,10 +42,6 @@ class BaseScopeGuardV2:
 
         return decorator
 
-    @classmethod
-    def maybe_map_model(cls, model: str) -> str:
-        return model
-
     def __new__(
         cls,
         backend: str = "vllm",

--- a/src/orbitals/scope_guard_v2/guards/base.py
+++ b/src/orbitals/scope_guard_v2/guards/base.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Literal, overload
+
+from pydantic import ValidationError
+
+if TYPE_CHECKING:
+    from .api import APIScopeGuardV2, AsyncAPIScopeGuardV2
+    from .hf import HuggingFaceScopeGuardV2
+    from .vllm import AsyncVLLMApiScopeGuardV2, VLLMScopeGuardV2
+
+from ...types import AIServiceDescriptionV2
+from ..modeling import (
+    ScopeGuardV2Input,
+    ScopeGuardV2InputTypeAdapter,
+    ScopeGuardV2Output,
+)
+from ..safety_principles import augment_with_default_safety_principles_v2
+
+
+class BaseScopeGuardV2:
+    _registry: dict[str, dict[str, type[ScopeGuardV2 | AsyncScopeGuardV2]]] = {}
+
+    @classmethod
+    def _get_outer_registry_key(cls) -> str:
+        return "async" if issubclass(cls, AsyncScopeGuardV2) else "sync"
+
+    @classmethod
+    def register_guard(cls, backend: str):
+        """Class decorator for registering a backend."""
+        outer_registry_key = cls._get_outer_registry_key()
+        if outer_registry_key not in cls._registry:
+            cls._registry[outer_registry_key] = {}
+
+        def decorator(subclass):
+            if backend in cls._registry[outer_registry_key]:
+                raise ValueError(f"Backend '{backend}' already registered")
+
+            cls._registry[outer_registry_key][backend] = subclass
+            return subclass
+
+        return decorator
+
+    @classmethod
+    def maybe_map_model(cls, model: str) -> str:
+        return model
+
+    def __new__(
+        cls,
+        backend: str = "vllm",
+        *args,
+        **kwargs,
+    ):
+        if cls is not ScopeGuardV2 and cls is not AsyncScopeGuardV2:
+            return super().__new__(cls)
+
+        try:
+            subclass = cls._registry[cls._get_outer_registry_key()][backend]
+        except KeyError:
+            raise ValueError(
+                f"Unknown backend '{backend}'. Available: {list(cls._registry[cls._get_outer_registry_key()].keys())}"
+            )
+
+        return super().__new__(subclass)
+
+    def __init__(
+        self,
+        backend: str,
+        *args,
+        include_default_safety_principles: bool = False,
+        **kwargs,
+    ):
+        self.backend = backend
+        self.include_default_safety_principles = include_default_safety_principles
+
+    def _resolve_include_default_safety_principles(
+        self, per_call_value: bool | None
+    ) -> bool:
+        if per_call_value is not None:
+            return per_call_value
+        return getattr(self, "include_default_safety_principles", False)
+
+    def _maybe_augment(
+        self,
+        ai_service_description: str | AIServiceDescriptionV2 | None,
+        include: bool,
+    ) -> str | AIServiceDescriptionV2 | None:
+        if not include or ai_service_description is None:
+            return ai_service_description
+        return augment_with_default_safety_principles_v2(ai_service_description)
+
+    def _maybe_augment_list(
+        self,
+        ai_service_descriptions: list[str] | list[AIServiceDescriptionV2] | None,
+        include: bool,
+    ) -> list[str] | list[AIServiceDescriptionV2] | None:
+        if not include or ai_service_descriptions is None:
+            return ai_service_descriptions
+        return [
+            augment_with_default_safety_principles_v2(ad)
+            for ad in ai_service_descriptions
+        ]  # type: ignore[return-value]
+
+    def _validate_conversation(
+        self, conversation: str | dict | list[dict]
+    ) -> ScopeGuardV2Input:
+        try:
+            return ScopeGuardV2InputTypeAdapter.validate_python(conversation)
+        except ValidationError as e:
+            logging.error("Invalid input format for conversation")
+            raise e from None
+
+    def _validate_conversations(
+        self, conversations: list[str] | list[dict] | list[list[dict]]
+    ) -> list[ScopeGuardV2Input]:
+        validated_conversations = []
+        for c in conversations:
+            try:
+                validated_conversations.append(self._validate_conversation(c))
+            except ValidationError as e:
+                logging.error("Invalid input format for conversation")
+                raise e from None
+        return validated_conversations
+
+    def _validate_ai_service_description_input(
+        self,
+        conversations: list[ScopeGuardV2Input],
+        ai_service_description: str | AIServiceDescriptionV2 | None,
+        ai_service_descriptions: list[str] | list[AIServiceDescriptionV2] | None,
+    ):
+        if bool(ai_service_description is not None) == bool(
+            ai_service_descriptions is not None
+        ):
+            if ai_service_description is not None:
+                raise ValueError(
+                    "Only one between [ai_service_description, ai_service_descriptions] must be provided"
+                )
+            else:
+                raise ValueError(
+                    "Either ai_service_description or ai_service_descriptions must be provided"
+                )
+
+        if ai_service_descriptions is not None and len(conversations) != len(
+            ai_service_descriptions
+        ):
+            raise ValueError(
+                "The number of conversations and ai_service_descriptions must be the same"
+            )
+
+
+class ScopeGuardV2(BaseScopeGuardV2):
+    @overload
+    def __new__(
+        cls,
+        backend: Literal["vllm"],
+        model: str,
+        skip_evidences: bool = False,
+        temperature: float = 0.0,
+        max_tokens: int = 3000,
+        max_model_len: int = 30_000,
+        max_num_seqs: int = 2,
+        gpu_memory_utilization: float = 0.9,
+        include_default_safety_principles: bool = False,
+    ) -> VLLMScopeGuardV2: ...
+
+    @overload
+    def __new__(
+        cls,
+        backend: Literal["hf"],
+        model: str,
+        skip_evidences: bool = False,
+        max_new_tokens: int = 3000,
+        do_sample: bool = False,
+        include_default_safety_principles: bool = False,
+        **kwargs,
+    ) -> HuggingFaceScopeGuardV2: ...
+
+    @overload
+    def __new__(
+        cls,
+        backend: Literal["api"],
+        model: str | None = None,
+        api_url: str = "http://localhost:8000",
+        api_key: str | None = None,
+        skip_evidences: bool = False,
+        custom_headers: dict[str, str] | None = None,
+        include_default_safety_principles: bool = False,
+    ) -> APIScopeGuardV2: ...
+
+    def __new__(cls, backend: str = "vllm", *args, **kwargs):
+        return super().__new__(cls, backend, *args, **kwargs)
+
+    def validate(
+        self,
+        conversation: str | dict | list[dict],
+        *,
+        ai_service_description: str | AIServiceDescriptionV2,
+        skip_evidences: bool | None = None,
+        include_default_safety_principles: bool | None = None,
+        **kwargs,
+    ) -> ScopeGuardV2Output:
+        conversation = self._validate_conversation(conversation)
+        include = self._resolve_include_default_safety_principles(
+            include_default_safety_principles
+        )
+        ai_service_description = self._maybe_augment(ai_service_description, include)
+        return self._validate(
+            conversation,
+            ai_service_description=ai_service_description,
+            skip_evidences=skip_evidences,
+            **kwargs,
+        )
+
+    def _validate(
+        self,
+        conversation: ScopeGuardV2Input,
+        *,
+        ai_service_description: str | AIServiceDescriptionV2,
+        skip_evidences: bool | None = None,
+        **kwargs,
+    ) -> ScopeGuardV2Output:
+        raise NotImplementedError
+
+    def batch_validate(
+        self,
+        conversations: list[str] | list[dict] | list[list[dict]],
+        *,
+        ai_service_description: str | AIServiceDescriptionV2 | None = None,
+        ai_service_descriptions: list[str] | list[AIServiceDescriptionV2] | None = None,
+        skip_evidences: bool | None = None,
+        include_default_safety_principles: bool | None = None,
+        **kwargs,
+    ) -> list[ScopeGuardV2Output]:
+        if len(conversations) == 0:
+            return []
+
+        validated_conversations = self._validate_conversations(conversations)
+        self._validate_ai_service_description_input(
+            validated_conversations, ai_service_description, ai_service_descriptions
+        )
+
+        include = self._resolve_include_default_safety_principles(
+            include_default_safety_principles
+        )
+        ai_service_description = self._maybe_augment(ai_service_description, include)
+        ai_service_descriptions = self._maybe_augment_list(
+            ai_service_descriptions, include
+        )
+
+        return self._batch_validate(
+            validated_conversations,
+            ai_service_description=ai_service_description,
+            ai_service_descriptions=ai_service_descriptions,
+            skip_evidences=skip_evidences,
+            **kwargs,
+        )
+
+    def _batch_validate(
+        self,
+        conversations: list[ScopeGuardV2Input],
+        *,
+        ai_service_description: str | AIServiceDescriptionV2 | None = None,
+        ai_service_descriptions: list[str] | list[AIServiceDescriptionV2] | None = None,
+        skip_evidences: bool | None = None,
+        **kwargs,
+    ) -> list[ScopeGuardV2Output]:
+        raise NotImplementedError
+
+
+class AsyncScopeGuardV2(BaseScopeGuardV2):
+    @overload
+    def __new__(
+        cls,
+        backend: Literal["vllm-api"],
+        model: str,
+        skip_evidences: bool = False,
+        vllm_serving_url: str = "http://localhost:8000",
+        temperature: float = 0.0,
+        max_tokens: int = 3000,
+        chat_templating_tokenizer: str | None = None,
+        count_system_prompt_in_usage: bool = False,
+        include_default_safety_principles: bool = False,
+    ) -> AsyncVLLMApiScopeGuardV2: ...
+
+    @overload
+    def __new__(
+        cls,
+        backend: Literal["api"],
+        model: str | None = None,
+        api_url: str = "http://localhost:8000",
+        api_key: str | None = None,
+        skip_evidences: bool = False,
+        custom_headers: dict[str, str] | None = None,
+        include_default_safety_principles: bool = False,
+    ) -> AsyncAPIScopeGuardV2: ...
+
+    def __new__(cls, backend: str, *args, **kwargs):
+        return super().__new__(cls, backend, *args, **kwargs)
+
+    async def validate(
+        self,
+        conversation: str | dict | list[dict],
+        *,
+        ai_service_description: str | AIServiceDescriptionV2,
+        skip_evidences: bool | None = None,
+        include_default_safety_principles: bool | None = None,
+        **kwargs,
+    ) -> ScopeGuardV2Output:
+        conversation = self._validate_conversation(conversation)
+        include = self._resolve_include_default_safety_principles(
+            include_default_safety_principles
+        )
+        ai_service_description = self._maybe_augment(ai_service_description, include)
+        return await self._validate(
+            conversation,
+            ai_service_description=ai_service_description,
+            skip_evidences=skip_evidences,
+            **kwargs,
+        )
+
+    async def _validate(
+        self,
+        conversation: ScopeGuardV2Input,
+        *,
+        ai_service_description: str | AIServiceDescriptionV2,
+        skip_evidences: bool | None = None,
+        **kwargs,
+    ) -> ScopeGuardV2Output:
+        raise NotImplementedError
+
+    async def batch_validate(
+        self,
+        conversations: list[str] | list[dict] | list[list[dict]],
+        *,
+        ai_service_description: str | AIServiceDescriptionV2 | None = None,
+        ai_service_descriptions: list[str] | list[AIServiceDescriptionV2] | None = None,
+        skip_evidences: bool | None = None,
+        include_default_safety_principles: bool | None = None,
+        **kwargs,
+    ) -> list[ScopeGuardV2Output]:
+        if len(conversations) == 0:
+            return []
+
+        validated_conversations = self._validate_conversations(conversations)
+        self._validate_ai_service_description_input(
+            validated_conversations, ai_service_description, ai_service_descriptions
+        )
+
+        include = self._resolve_include_default_safety_principles(
+            include_default_safety_principles
+        )
+        ai_service_description = self._maybe_augment(ai_service_description, include)
+        ai_service_descriptions = self._maybe_augment_list(
+            ai_service_descriptions, include
+        )
+
+        return await self._batch_validate(
+            validated_conversations,
+            ai_service_description=ai_service_description,
+            ai_service_descriptions=ai_service_descriptions,
+            skip_evidences=skip_evidences,
+            **kwargs,
+        )
+
+    async def _batch_validate(
+        self,
+        conversations: list[ScopeGuardV2Input],
+        *,
+        ai_service_description: str | AIServiceDescriptionV2 | None = None,
+        ai_service_descriptions: list[str] | list[AIServiceDescriptionV2] | None = None,
+        skip_evidences: bool | None = None,
+        **kwargs,
+    ) -> list[ScopeGuardV2Output]:
+        raise NotImplementedError

--- a/src/orbitals/scope_guard_v2/guards/hf.py
+++ b/src/orbitals/scope_guard_v2/guards/hf.py
@@ -1,0 +1,124 @@
+import json
+from typing import TYPE_CHECKING, Literal
+
+import pydantic
+
+if TYPE_CHECKING:
+    from transformers import pipeline  # noqa: F401
+
+from ...types import AIServiceDescriptionV2
+from ..modeling import ScopeGuardV2Input, ScopeGuardV2Output
+from ..prompting import ScopeGuardV2ResponseModel
+from .base import ScopeGuardV2
+
+
+@ScopeGuardV2.register_guard("hf")
+class HuggingFaceScopeGuardV2(ScopeGuardV2):
+    def __init__(
+        self,
+        backend: Literal["hf"] = "hf",
+        model: str | None = None,
+        skip_evidences: bool = False,
+        max_new_tokens: int = 3000,
+        do_sample: bool = False,
+        include_default_safety_principles: bool = False,
+        **kwargs,
+    ):
+        from ...utils import maybe_configure_gpu_usage
+
+        maybe_configure_gpu_usage()
+
+        from transformers import pipeline  # noqa: F401
+
+        super().__init__(
+            backend,
+            include_default_safety_principles=include_default_safety_principles,
+        )
+        if model is None:
+            raise ValueError("A model name must be provided for ScopeGuardV2.")
+        self.model = self.maybe_map_model(model)
+        self._pipeline = pipeline(
+            task="scope-guard-v2",
+            model=self.model,
+            trust_remote_code=True,
+            skip_evidences=skip_evidences,
+            max_new_tokens=max_new_tokens,
+            do_sample=do_sample,
+            **kwargs,
+        )  # type: ignore # ty: ignore[no-matching-overload]
+
+    def _validate(
+        self,
+        conversation: ScopeGuardV2Input,
+        *,
+        ai_service_description: str | AIServiceDescriptionV2,
+        skip_evidences: bool | None = None,
+        **kwargs,
+    ) -> ScopeGuardV2Output:
+        generated_text = self._pipeline(
+            inputs=(conversation, ai_service_description),
+            **(
+                {"skip_evidences": skip_evidences} if skip_evidences is not None else {}
+            ),
+        )[0]["generated_text"]
+
+        try:
+            parsed_obj = json.loads(generated_text)
+        except json.JSONDecodeError:
+            raise ValueError(f"Failed to parse generated text: {generated_text}")
+
+        try:
+            validated_obj = ScopeGuardV2ResponseModel.model_validate(parsed_obj)
+        except pydantic.ValidationError as e:
+            raise ValueError(f"Failed to validate generated text: {e}")
+
+        return ScopeGuardV2Output(
+            scope_class=validated_obj.scope_class,
+            evidences=validated_obj.evidences,
+            reasoning=validated_obj.reasoning,
+            suggested_response=validated_obj.suggested_response,
+            model=self.model,
+            usage=None,
+        )
+
+    def _batch_validate(
+        self,
+        conversations: list[ScopeGuardV2Input],
+        *,
+        ai_service_description: str | AIServiceDescriptionV2 | None = None,
+        ai_service_descriptions: list[str] | list[AIServiceDescriptionV2] | None = None,
+        skip_evidences: bool | None = None,
+        **kwargs,
+    ) -> list[ScopeGuardV2Output]:
+        if ai_service_descriptions is not None:
+            pipeline_inputs = [
+                (c, ad) for c, ad in zip(conversations, ai_service_descriptions)
+            ]
+        elif ai_service_description is not None:
+            pipeline_inputs = [(c, ai_service_description) for c in conversations]
+        else:
+            raise ValueError
+
+        pipeline_outputs = self._pipeline(
+            pipeline_inputs,
+            **(
+                {"skip_evidences": skip_evidences} if skip_evidences is not None else {}
+            ),
+        )
+
+        results = []
+        for pipeline_output in pipeline_outputs:
+            parsed_obj = json.loads(pipeline_output[0]["generated_text"])
+            validated_obj = ScopeGuardV2ResponseModel.model_validate(parsed_obj)
+            results.append(
+                ScopeGuardV2Output(
+                    evidences=validated_obj.evidences,
+                    reasoning=validated_obj.reasoning,
+                    scope_class=validated_obj.scope_class,
+                    suggested_response=validated_obj.suggested_response,
+                    model=self.model,
+                    usage=None,
+                )
+            )
+
+        return results

--- a/src/orbitals/scope_guard_v2/guards/hf.py
+++ b/src/orbitals/scope_guard_v2/guards/hf.py
@@ -36,7 +36,7 @@ class HuggingFaceScopeGuardV2(ScopeGuardV2):
         )
         if model is None:
             raise ValueError("A model name must be provided for ScopeGuardV2.")
-        self.model = self.maybe_map_model(model)
+        self.model = model
         self._pipeline = pipeline(
             task="scope-guard-v2",
             model=self.model,

--- a/src/orbitals/scope_guard_v2/guards/vllm.py
+++ b/src/orbitals/scope_guard_v2/guards/vllm.py
@@ -51,7 +51,7 @@ class VLLMScopeGuardV2(ScopeGuardV2):
         )
         if model is None:
             raise ValueError("A model name must be provided for ScopeGuardV2.")
-        self.model = self.maybe_map_model(model)
+        self.model = model
         self.skip_evidences = skip_evidences
         self.llm = vllm.LLM(
             model=self.model,
@@ -156,9 +156,9 @@ class AsyncVLLMApiScopeGuardV2(AsyncScopeGuardV2):
         )
         if model is None:
             raise ValueError("A model name must be provided for AsyncScopeGuardV2.")
-        self.default_model_name = self.maybe_map_model(model)
+        self.default_model_name = model
         self.default_tokenizer_name = (
-            self.maybe_map_model(chat_templating_tokenizer)
+            chat_templating_tokenizer
             if chat_templating_tokenizer is not None
             else self.default_model_name
         )
@@ -177,10 +177,8 @@ class AsyncVLLMApiScopeGuardV2(AsyncScopeGuardV2):
         prefill: bool,
         chat_templating_tokenizer: str | None = None,
     ) -> ScopeGuardV2Output:
-        model_name = self.maybe_map_model(model_name) if model_name is not None else None
-
         if chat_templating_tokenizer is not None:
-            tokenizer = _get_tokenizer(self.maybe_map_model(chat_templating_tokenizer))
+            tokenizer = _get_tokenizer(chat_templating_tokenizer)
         elif model_name is not None:
             tokenizer = _get_tokenizer(model_name)
         else:
@@ -290,6 +288,8 @@ class AsyncVLLMApiScopeGuardV2(AsyncScopeGuardV2):
                 conversation=c,
                 ai_service_description=aisd,
                 skip_evidences=skip_evidences,
+                # TODO supporting True on this parameter is a bit tricky
+                # problem is the grammar-based decoding, which is unaware of the prefilling
                 prefill=False,
                 chat_templating_tokenizer=chat_templating_tokenizer,
             )

--- a/src/orbitals/scope_guard_v2/guards/vllm.py
+++ b/src/orbitals/scope_guard_v2/guards/vllm.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from functools import lru_cache
+from typing import TYPE_CHECKING, Literal
+
+import aiohttp
+import pydantic
+
+if TYPE_CHECKING:
+    import transformers  # noqa: F401
+    import vllm  # noqa: F401
+
+from ...types import AIServiceDescriptionV2, LLMUsage
+from ..modeling import ScopeGuardV2Input, ScopeGuardV2Output
+from ..prompting import SYSTEM_PROMPT, ScopeGuardV2ResponseModel, build_prompt
+from .base import AsyncScopeGuardV2, ScopeGuardV2
+
+
+@lru_cache(maxsize=8)
+def _get_tokenizer(model_name: str) -> transformers.PreTrainedTokenizer:
+    import transformers
+
+    return transformers.AutoTokenizer.from_pretrained(model_name)
+
+
+@ScopeGuardV2.register_guard("vllm")
+class VLLMScopeGuardV2(ScopeGuardV2):
+    def __init__(
+        self,
+        backend: Literal["vllm"] = "vllm",
+        model: str | None = None,
+        skip_evidences: bool = False,
+        temperature: float = 0.0,
+        max_tokens: int = 3000,
+        max_model_len: int = 30_000,
+        max_num_seqs: int = 2,
+        gpu_memory_utilization: float = 0.9,
+        include_default_safety_principles: bool = False,
+    ):
+        from ...utils import maybe_configure_gpu_usage
+
+        maybe_configure_gpu_usage()
+
+        import vllm
+
+        super().__init__(
+            backend,
+            include_default_safety_principles=include_default_safety_principles,
+        )
+        if model is None:
+            raise ValueError("A model name must be provided for ScopeGuardV2.")
+        self.model = self.maybe_map_model(model)
+        self.skip_evidences = skip_evidences
+        self.llm = vllm.LLM(
+            model=self.model,
+            max_model_len=max_model_len,
+            max_num_seqs=max_num_seqs,
+            gpu_memory_utilization=gpu_memory_utilization,
+        )
+        self.tokenizer = _get_tokenizer(self.model)
+        self.sampling_params = vllm.SamplingParams(
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+
+    def _validate(
+        self,
+        conversation: ScopeGuardV2Input,
+        *,
+        ai_service_description: str | AIServiceDescriptionV2,
+        skip_evidences: bool | None = None,
+        **kwargs,
+    ) -> ScopeGuardV2Output:
+        return self._batch_validate(
+            [conversation],
+            ai_service_description=ai_service_description,
+            skip_evidences=skip_evidences,
+        )[0]
+
+    def _batch_validate(
+        self,
+        conversations: list[ScopeGuardV2Input],
+        *,
+        ai_service_description: str | AIServiceDescriptionV2 | None = None,
+        ai_service_descriptions: list[str] | list[AIServiceDescriptionV2] | None = None,
+        skip_evidences: bool | None = None,
+        **kwargs,
+    ) -> list[ScopeGuardV2Output]:
+        resolved_skip_evidences = (
+            skip_evidences if skip_evidences is not None else self.skip_evidences
+        )
+
+        if ai_service_descriptions is not None:
+            prompts = [
+                build_prompt(
+                    self.tokenizer,
+                    c,
+                    ad,
+                    skip_evidences=resolved_skip_evidences,
+                )
+                for c, ad in zip(conversations, ai_service_descriptions)
+            ]
+        elif ai_service_description is not None:
+            prompts = [
+                build_prompt(
+                    self.tokenizer,
+                    c,
+                    ai_service_description,
+                    skip_evidences=resolved_skip_evidences,
+                )
+                for c in conversations
+            ]
+        else:
+            raise ValueError
+
+        outputs = self.llm.generate(prompts, self.sampling_params, use_tqdm=False)
+
+        results = []
+        for output in outputs:
+            text = output.outputs[0].text
+            parsed_obj = json.loads(text)
+            validated_obj = ScopeGuardV2ResponseModel.model_validate(parsed_obj)
+            results.append(
+                ScopeGuardV2Output(
+                    evidences=validated_obj.evidences,
+                    reasoning=validated_obj.reasoning,
+                    scope_class=validated_obj.scope_class,
+                    suggested_response=validated_obj.suggested_response,
+                    model=self.model,
+                    usage=None,
+                )
+            )
+
+        return results
+
+
+@AsyncScopeGuardV2.register_guard("vllm-api")
+class AsyncVLLMApiScopeGuardV2(AsyncScopeGuardV2):
+    def __init__(
+        self,
+        backend: Literal["vllm-api", "vllm-async-api"] = "vllm-api",
+        model: str | None = None,
+        skip_evidences: bool = False,
+        vllm_serving_url: str = "http://localhost:8000",
+        temperature: float = 0.0,
+        max_tokens: int = 3000,
+        chat_templating_tokenizer: str | None = None,
+        count_system_prompt_in_usage: bool = False,
+        include_default_safety_principles: bool = False,
+    ):
+        super().__init__(
+            backend,
+            include_default_safety_principles=include_default_safety_principles,
+        )
+        if model is None:
+            raise ValueError("A model name must be provided for AsyncScopeGuardV2.")
+        self.default_model_name = self.maybe_map_model(model)
+        self.default_tokenizer_name = (
+            self.maybe_map_model(chat_templating_tokenizer)
+            if chat_templating_tokenizer is not None
+            else self.default_model_name
+        )
+        self.skip_evidences = skip_evidences
+        self.vllm_serving_url = vllm_serving_url
+        self.vllm_temperature = temperature
+        self.vllm_max_tokens = max_tokens
+        self.count_system_prompt_in_usage = count_system_prompt_in_usage
+
+    async def _handle_request(
+        self,
+        model_name: str | None,
+        conversation: ScopeGuardV2Input,
+        ai_service_description: str | AIServiceDescriptionV2,
+        skip_evidences: bool | None,
+        prefill: bool,
+        chat_templating_tokenizer: str | None = None,
+    ) -> ScopeGuardV2Output:
+        model_name = self.maybe_map_model(model_name) if model_name is not None else None
+
+        if chat_templating_tokenizer is not None:
+            tokenizer = _get_tokenizer(self.maybe_map_model(chat_templating_tokenizer))
+        elif model_name is not None:
+            tokenizer = _get_tokenizer(model_name)
+        else:
+            tokenizer = _get_tokenizer(self.default_tokenizer_name)
+
+        model_name = model_name if model_name is not None else self.default_model_name
+        skip_evidences = (
+            skip_evidences if skip_evidences is not None else self.skip_evidences
+        )
+
+        prompt = build_prompt(
+            tokenizer=tokenizer,
+            conversation=conversation,
+            ai_service_description=ai_service_description,
+            skip_evidences=skip_evidences,
+            prefill=prefill,
+        )
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{self.vllm_serving_url}/v1/completions",
+                json={
+                    "model": model_name,
+                    "prompt": prompt,
+                    "temperature": self.vllm_temperature,
+                    "max_tokens": self.vllm_max_tokens,
+                    "structured_outputs": {
+                        "json": ScopeGuardV2ResponseModel.model_json_schema()
+                    },
+                },
+                headers={"Content-Type": "application/json"},
+            ) as response:
+                response.raise_for_status()
+                response_json = await response.json()
+                response_text = response_json["choices"][0]["text"]
+
+        if prefill:
+            response_text = prompt[prompt.rindex('{"evidences"') :] + response_text
+
+        try:
+            parsed_obj = json.loads(response_text)
+        except json.JSONDecodeError:
+            raise ValueError(f"Failed to parse generated text: {response_json}")
+
+        try:
+            validated_obj = ScopeGuardV2ResponseModel.model_validate(parsed_obj)
+        except pydantic.ValidationError as e:
+            raise ValueError(f"Failed to validate generated text: {e}")
+
+        system_prompt_tokens = (
+            0
+            if self.count_system_prompt_in_usage
+            else len(tokenizer.encode(SYSTEM_PROMPT))
+        )
+
+        return ScopeGuardV2Output(
+            scope_class=validated_obj.scope_class,
+            evidences=validated_obj.evidences,
+            reasoning=validated_obj.reasoning,
+            suggested_response=validated_obj.suggested_response,
+            model=model_name,
+            usage=LLMUsage(
+                prompt_tokens=response_json["usage"]["prompt_tokens"]
+                - system_prompt_tokens,
+                completion_tokens=response_json["usage"]["completion_tokens"],
+                total_tokens=response_json["usage"]["total_tokens"]
+                - system_prompt_tokens,
+            ),
+        )
+
+    async def _validate(
+        self,
+        conversation: ScopeGuardV2Input,
+        *,
+        ai_service_description: str | AIServiceDescriptionV2,
+        skip_evidences: bool | None = None,
+        model: str | None = None,
+        chat_templating_tokenizer: str | None = None,
+        **kwargs,
+    ) -> ScopeGuardV2Output:
+        results = await self._batch_validate(
+            conversations=[conversation],
+            ai_service_description=ai_service_description,
+            skip_evidences=skip_evidences,
+            model=model,
+            chat_templating_tokenizer=chat_templating_tokenizer,
+        )
+        return results[0]
+
+    async def _batch_validate(
+        self,
+        conversations: list[ScopeGuardV2Input],
+        *,
+        ai_service_description: str | AIServiceDescriptionV2 | None = None,
+        ai_service_descriptions: list[str] | list[AIServiceDescriptionV2] | None = None,
+        skip_evidences: bool | None = None,
+        model: str | None = None,
+        chat_templating_tokenizer: str | None = None,
+        **kwargs,
+    ) -> list[ScopeGuardV2Output]:
+        if ai_service_description is not None:
+            ai_service_descriptions = [ai_service_description] * len(conversations)  # type: ignore[invalid-assignment]
+
+        tasks = [
+            self._handle_request(
+                model_name=model,
+                conversation=c,
+                ai_service_description=aisd,
+                skip_evidences=skip_evidences,
+                prefill=False,
+                chat_templating_tokenizer=chat_templating_tokenizer,
+            )
+            for c, aisd in zip(conversations, ai_service_descriptions)  # type: ignore[invalid-argument-type]
+        ]
+        results = await asyncio.gather(*tasks)
+
+        return results

--- a/src/orbitals/scope_guard_v2/modeling.py
+++ b/src/orbitals/scope_guard_v2/modeling.py
@@ -25,7 +25,6 @@ class ScopeClass(str, Enum):
     POTENTIALLY_SUPPORTED = "Potentially Supported"
     PREDEFINED_ANSWER = "Predefined Answer"
     HUMAN_OVERSIGHT = "Human Oversight"
-    HUMAN_REVIEW = "Human Oversight"
     OUT_OF_SCOPE = "Out of Scope"
     RESTRICTED = "Restricted"
     CHIT_CHAT = "Chit Chat"

--- a/src/orbitals/scope_guard_v2/modeling.py
+++ b/src/orbitals/scope_guard_v2/modeling.py
@@ -1,0 +1,117 @@
+from enum import Enum
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, BeforeValidator, Field, TypeAdapter
+
+from ..types import ConversationMessage, LLMUsage
+
+
+class ScopeClassDefinition(BaseModel):
+    """Definition of a scope classification class"""
+
+    name: str = Field(description="Name of the scope class")
+    description: str = Field(
+        description="Description of when this classification applies"
+    )
+
+    def dumps(self) -> str:
+        return f"{self.name}: {self.description}"
+
+
+class ScopeClass(str, Enum):
+    """Constants for scope class names"""
+
+    DIRECTLY_SUPPORTED = "Directly Supported"
+    POTENTIALLY_SUPPORTED = "Potentially Supported"
+    PREDEFINED_ANSWER = "Predefined Answer"
+    HUMAN_OVERSIGHT = "Human Oversight"
+    HUMAN_REVIEW = "Human Oversight"
+    OUT_OF_SCOPE = "Out of Scope"
+    RESTRICTED = "Restricted"
+    CHIT_CHAT = "Chit Chat"
+
+    @property
+    def description(self) -> str:
+        return _SCOPE_DESCRIPTIONS[self]
+
+    @classmethod
+    def get_all_definitions(cls) -> list[ScopeClassDefinition]:
+        """Get all scope class definitions"""
+        return SCOPE_CLASSES
+
+    @classmethod
+    def get_definition(cls, name: str) -> ScopeClassDefinition | None:
+        """Get definition for a specific scope class"""
+        for definition in SCOPE_CLASSES:
+            if definition.name == name:
+                return definition
+        return None
+
+    @classmethod
+    def get_classes_manifest(cls) -> str:
+        """Get a prompt-friendly description of all scope classes."""
+        return "\n".join(f"- {definition.dumps()}" for definition in SCOPE_CLASSES)
+
+
+_SCOPE_DESCRIPTIONS = {
+    ScopeClass.DIRECTLY_SUPPORTED: "The query is clearly within the scope of the AI service. The AI service can and should handle this type of request.",
+    ScopeClass.POTENTIALLY_SUPPORTED: "The query is plausibly within the scope of the AI service. In most situations, it's generally safe for the AI service to handle this, but may require careful consideration.",
+    ScopeClass.PREDEFINED_ANSWER: "The query matches a predefined scenario or FAQ that has a specific, pre-written response. Use the exact predefined response.",
+    ScopeClass.HUMAN_OVERSIGHT: "The query requires human oversight, judgment, or expertise. This could be due to complexity, sensitivity, legal implications, or escalation criteria being met.",
+    ScopeClass.OUT_OF_SCOPE: "The query is outside the scope of the AI service and its responsibilities. The AI service should not process this type of request.",
+    ScopeClass.RESTRICTED: "The query requests something that is explicitly forbidden or restricted. The AI service must never process this type of request.",
+    ScopeClass.CHIT_CHAT: "Social pleasantries, small talk, or casual conversation not related to the service (e.g., 'thank you', 'goodbye', 'how are you'). Does not require substantial service assistance.",
+}
+
+
+SCOPE_CLASSES = [
+    ScopeClassDefinition(name=scope_class.value, description=scope_class.description)
+    for scope_class in ScopeClass
+]
+
+
+class ScopeGuardV2Output(BaseModel):
+    evidences: list[str] | None = Field(
+        default=None,
+        description="Evidences from the AI Service Description supporting this classification.",
+    )
+    reasoning: str = Field(
+        description="A short explanation of why this classification was chosen."
+    )
+    scope_class: ScopeClass = Field(
+        description="The scope classification (must be one of the defined scope classes)."
+    )
+    suggested_response: str | None = Field(
+        default=None, description="A short suggested answer or message for the user."
+    )
+    model: str = Field(description="The model used to produce this classification.")
+    usage: LLMUsage | None = Field(
+        default=None, description="Token usage reported by the model backend."
+    )
+
+
+class ConversationUserMessage(BaseModel):
+    role: Literal["user"]
+    content: str
+
+
+def _select_model_based_on_fields(
+    v: Any,
+) -> str | ConversationUserMessage | list[ConversationMessage]:
+    if isinstance(v, str):
+        return TypeAdapter(str).validate_python(v)
+    elif isinstance(v, dict):
+        return TypeAdapter(ConversationUserMessage).validate_python(v)
+    elif isinstance(v, list):
+        return TypeAdapter(list[ConversationMessage]).validate_python(v)
+
+    # no matching model found, let's fall back to standard pydantic behavior
+    return v
+
+
+ScopeGuardV2Input = Annotated[
+    str | ConversationUserMessage | list[ConversationMessage],
+    BeforeValidator(_select_model_based_on_fields),
+]
+
+ScopeGuardV2InputTypeAdapter = TypeAdapter(ScopeGuardV2Input)

--- a/src/orbitals/scope_guard_v2/prompting.py
+++ b/src/orbitals/scope_guard_v2/prompting.py
@@ -53,13 +53,13 @@ The AI Service Description may be a structured document with labelled fields, or
 
 ## Instructions
 
-1. **Extract Evidences**: Identify and quote specific excerpts from the AI Service Description that are relevant to understanding whether and how the AI Service can handle the LAST USER MESSAGE. Look for:
+1. **Extract Evidences**: Identify and quote specific excerpts from the AI Service Description that are relevant to understanding whether and how the AI Service can handle the message tagged LAST MESSAGE. Look for:
    - Functionalities that might address the user's query
    - Constraints that would forbid or restrict the request
    - Knowledge Scope boundaries that the request may fall outside of
    - Predefined Responses whose trigger matches the request
    - Escalation Criteria that the request may meet
-2. **Contextualise**: Read the conversation for context. Prior messages provide context only; your classification must reflect the intent of the message tagged LAST USER MESSAGE alone.
+2. **Contextualise**: Read the conversation for context. Prior messages provide context only; your classification must reflect the intent of the message tagged LAST MESSAGE alone.
 3. **Classify**: Based on the evidence extracted, assign exactly one of the scope classes above. If the message could fall under multiple classes, prefer the more specific or more restrictive one (e.g. "Restricted" over "Out of Scope", "Directly Supported" over "Potentially Supported").
 4. **Respond**: Provide:
    - `evidences`: verbatim quotes from the AI service description that support your choice (or null if not applicable)

--- a/src/orbitals/scope_guard_v2/prompting.py
+++ b/src/orbitals/scope_guard_v2/prompting.py
@@ -1,0 +1,189 @@
+import json
+
+from pydantic import BaseModel, Field
+
+from ..types import AIServiceDescriptionV2, Conversation, ConversationMessage
+from .modeling import (
+    ConversationUserMessage,
+    ScopeClass,
+    ScopeGuardV2Input,
+    ScopeGuardV2InputTypeAdapter,
+)
+
+
+class ScopeGuardV2ResponseModel(BaseModel):
+    evidences: list[str] | None = Field(
+        default=None,
+        description="Evidences from the AI Service Description supporting this classification.",
+    )
+    reasoning: str = Field(
+        description="A short explanation of why this classification was chosen."
+    )
+    scope_class: ScopeClass = Field(
+        description="The scope classification (must be one of the defined scope classes)."
+    )
+    suggested_response: str | None = Field(
+        default=None, description="A short suggested answer or message for the user."
+    )
+
+
+_SCOPE_CLASSES_BLOCK = ScopeClass.get_classes_manifest()
+_RESPONSE_SCHEMA = json.dumps(ScopeGuardV2ResponseModel.model_json_schema())
+
+SYSTEM_PROMPT = f"""You are an expert AI classifier specialized in classifying user queries given the description of an AI service.
+
+Your task is to analyse a conversation and classify the last user message against the AI service description provided in the AI Service Description section below.
+
+## AI Service Description
+
+The AI Service Description may be a structured document with labelled fields, or a free-form text. Either way, when reading it you should identify the following conceptual categories — they may be explicitly labelled or simply implied by the prose:
+
+- **Identity & Role**: What the AI service is and what it is fundamentally meant to do.
+- **Context**: The company, sector, user base, or operating environment the service operates in.
+- **Knowledge Scope**: The subject-matter domains the service has expertise in. Anything clearly outside this scope is likely Out of Scope.
+- **Functionalities**: Specific capabilities or tasks the service can perform. Direct matches are strong evidence for "Directly Supported".
+- **Constraints**: Topics, actions, or behaviours the service must never engage in, regardless of how the request is phrased. Matches are strong evidence for "Restricted".
+- **Predefined Responses**: Specific triggers or questions that require a fixed, pre-written answer. Matches are strong evidence for "Predefined Answer".
+- **Escalation Criteria**: Situations (e.g. legal threats, safety concerns, fraud, but even specific use cases) that must be routed to a human. Matches are strong evidence for "Human Oversight".
+- **Response Guidelines**: Tone or style guidance — does not affect scope classification.
+
+## Available scope classes
+
+{_SCOPE_CLASSES_BLOCK}
+
+## Instructions
+
+1. **Extract Evidences**: Identify and quote specific excerpts from the AI Service Description that are relevant to understanding whether and how the AI Service can handle the LAST USER MESSAGE. Look for:
+   - Functionalities that might address the user's query
+   - Constraints that would forbid or restrict the request
+   - Knowledge Scope boundaries that the request may fall outside of
+   - Predefined Responses whose trigger matches the request
+   - Escalation Criteria that the request may meet
+2. **Contextualise**: Read the conversation for context. Prior messages provide context only; your classification must reflect the intent of the message tagged LAST USER MESSAGE alone.
+3. **Classify**: Based on the evidence extracted, assign exactly one of the scope classes above. If the message could fall under multiple classes, prefer the more specific or more restrictive one (e.g. "Restricted" over "Out of Scope", "Directly Supported" over "Potentially Supported").
+4. **Respond**: Provide:
+   - `evidences`: verbatim quotes from the AI service description that support your choice (or null if not applicable)
+   - `reasoning`: a short, useful explanation of why you chose that class. Prefer few sentences that mentions only the decisive evidence or rule. It must be in English, regardless of the language of the user message or service description, to ensure consistency in evaluation.
+   - `scope_class`: one of the exact scope class names listed above
+   - `suggested_response`: the shortest useful response for the user when the class is "Predefined Answer", "Human Oversight", "Out of Scope", "Restricted", or "Chit Chat"; it must still be meaningful, polite, and convey the required message clearly; otherwise null
+
+## Important Guidelines
+- Base your classification EXCLUSIVELY on the AI Service Description provided.
+- Give priority to **Predefined Responses** > **Escalation Criteria** > **Constraints** fields — they are hard rules that override other considerations.
+- When a **Predefined Response** trigger is matched, always classify as "Predefined Answer" and use the exact pre-written response.
+- Extract evidence first, then use it to inform your classification decision.
+- If at least one of the user requests / intents matches a constraint, predefined response, or escalation criterion, classify the request accordingly (respecting classes priorities) and **the suggested_response must reflect that, even if other aspects of the query could be considered "Directly Supported" or "Potentially Supported" completely ignore them**.
+- Keep `reasoning` and `suggested_response` as short as possible while preserving the meaning. Do not add filler, repeated explanations, or unnecessary detail.
+
+## Language
+- The suggested response must be in the same language as the user's message. If the user's message is in a language other than English, translate the predefined response or escalation instructions into that language while preserving the meaning as closely as possible.
+
+## Output Format
+You MUST respond with a single JSON object and nothing else — no markdown fences, no preamble, no explanation outside the JSON. The JSON must conform to this schema:
+{_RESPONSE_SCHEMA}
+"""
+
+
+LAST_MESSAGE_TAG = "LAST MESSAGE"
+
+
+def dumps_conversation(
+    conversation_or_message: Conversation | ConversationMessage | str,
+) -> str:
+    if isinstance(conversation_or_message, str):
+        conversation_or_message = ConversationMessage(
+            role="user", content=conversation_or_message
+        )
+    if isinstance(conversation_or_message, ConversationMessage):
+        conversation_or_message = Conversation(messages=[conversation_or_message])
+
+    if len(conversation_or_message.messages) == 0:
+        raise ValueError("Conversation must contain at least one message.")
+
+    if conversation_or_message.messages[-1].role != "user":
+        raise ValueError(
+            "The last message in the conversation must be from the user, representing the LAST USER MESSAGE to classify."
+        )
+
+    conversation_dump = ""
+
+    for message in conversation_or_message.messages[:-1]:
+        conversation_dump += f"{message.role.upper()}:\n{message.content}\n\n"
+
+    last_message = conversation_or_message.messages[-1]
+    conversation_dump += (
+        f"{LAST_MESSAGE_TAG} ({last_message.role.upper()}):\n{last_message.content}\n"
+    )
+
+    return conversation_dump
+
+
+def convert_to_conversation(messages: ScopeGuardV2Input) -> Conversation:
+    if isinstance(messages, str):
+        messages = [ConversationMessage(role="user", content=messages)]
+    elif isinstance(messages, list):
+        messages = [
+            ConversationMessage(role=message.role, content=message.content)
+            for message in messages
+        ]
+    elif isinstance(messages, ConversationUserMessage):
+        messages = [ConversationMessage(role=messages.role, content=messages.content)]
+    else:
+        messages = ScopeGuardV2InputTypeAdapter.validate_python(messages)
+
+    conversation = Conversation(messages=messages)
+    return conversation
+
+
+def prepare_input_messages(
+    conversation: ScopeGuardV2Input,
+    ai_service_description: AIServiceDescriptionV2 | str,
+    skip_evidences: bool = False,
+):
+    if isinstance(ai_service_description, AIServiceDescriptionV2):
+        ai_service_description = ai_service_description.model_dump_json()
+
+    _conv = convert_to_conversation(conversation)
+    conversation_dump = dumps_conversation(_conv)
+
+    user_input = f"**START OF THE AI SERVICE DESCRIPTION**\n\n{ai_service_description}\n\n**END OF THE AI SERVICE DESCRIPTION**\n\n\n"
+    user_input += f"**START OF THE CONVERSATION DUMP**\n\n{conversation_dump}\n\n**END OF THE CONVERSATION DUMP**"
+    if skip_evidences:
+        user_input += "\n\n**SKIP EVIDENCES**: do not report evidences, report only reasoning, scope_class, and suggested_response."
+
+    messages = [
+        {
+            "role": "system",
+            "content": SYSTEM_PROMPT,
+        },
+        {"role": "user", "content": user_input},
+    ]
+    return messages
+
+
+def build_prompt(
+    tokenizer,
+    conversation: ScopeGuardV2Input,
+    ai_service_description: AIServiceDescriptionV2 | str,
+    skip_evidences: bool = False,
+    prefill: bool = False,
+) -> str:
+    messages = prepare_input_messages(
+        conversation,
+        ai_service_description,
+        skip_evidences,
+    )
+    prompt = tokenizer.apply_chat_template(
+        messages,
+        tokenize=False,
+        add_generation_prompt=True,
+        enable_thinking=False,
+    )
+
+    if prefill:
+        if skip_evidences:
+            prompt += '{"evidences": null, "reasoning": "'
+        else:
+            prompt += '{"evidences":'
+
+    return prompt

--- a/src/orbitals/scope_guard_v2/safety_principles.py
+++ b/src/orbitals/scope_guard_v2/safety_principles.py
@@ -1,0 +1,28 @@
+from pydantic import ValidationError
+
+from ..types import AIServiceDescriptionV2
+from ..scope_guard.safety_principles import ADDITIONAL_SAFETY_RULES
+
+
+def _add_safety_constraints(desc: AIServiceDescriptionV2) -> AIServiceDescriptionV2:
+    if desc.constraints is None:
+        merged: list[str] = [ADDITIONAL_SAFETY_RULES]
+    elif isinstance(desc.constraints, str):
+        merged = [desc.constraints, ADDITIONAL_SAFETY_RULES]
+    else:
+        merged = [*desc.constraints, ADDITIONAL_SAFETY_RULES]
+    return desc.model_copy(update={"constraints": merged})
+
+
+def augment_with_default_safety_principles_v2(
+    ai_service_description: str | AIServiceDescriptionV2,
+) -> str | AIServiceDescriptionV2:
+    if isinstance(ai_service_description, AIServiceDescriptionV2):
+        return _add_safety_constraints(ai_service_description)
+
+    try:
+        parsed = AIServiceDescriptionV2.model_validate_json(ai_service_description)
+    except (ValueError, ValidationError):
+        return f"{ai_service_description}\n\n{ADDITIONAL_SAFETY_RULES}"
+
+    return _add_safety_constraints(parsed).model_dump_json()

--- a/src/orbitals/scope_guard_v2/serving/main.py
+++ b/src/orbitals/scope_guard_v2/serving/main.py
@@ -1,0 +1,124 @@
+import os
+import time
+from contextlib import asynccontextmanager
+from typing import Annotated
+
+from fastapi import Body, FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+from orbitals.scope_guard_v2 import AsyncScopeGuardV2
+from orbitals.scope_guard_v2.guards import AsyncVLLMApiScopeGuardV2
+from orbitals.scope_guard_v2.modeling import ScopeClass, ScopeGuardV2Input
+from orbitals.types import AIServiceDescriptionV2, LLMUsage
+
+scope_guard: AsyncVLLMApiScopeGuardV2
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global scope_guard
+
+    scope_guard = AsyncScopeGuardV2(  # type: ignore[invalid-assignment]
+        backend="vllm-api",
+        model=os.environ["SCOPE_GUARD_V2_VLLM_MODEL"],
+        skip_evidences=os.environ["SCOPE_GUARD_V2_SKIP_EVIDENCES"] == "1",
+        vllm_serving_url=os.environ["SCOPE_GUARD_V2_VLLM_SERVING_URL"],
+    )
+
+    yield
+
+
+app = FastAPI(
+    lifespan=lifespan,
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class ScopeGuardV2Response(BaseModel):
+    scope_class: ScopeClass
+    evidences: list[str] | None
+    reasoning: str
+    suggested_response: str | None
+    model: str
+    usage: LLMUsage
+    time_taken: float
+
+
+@app.post("/orbitals/scope-guard-v2/validate", response_model=ScopeGuardV2Response)
+async def validate(
+    conversation: ScopeGuardV2Input,
+    ai_service_description: Annotated[str | AIServiceDescriptionV2, Body()],
+    skip_evidences: Annotated[bool | None, Body()] = None,
+    model: Annotated[str | None, Body()] = None,
+    include_default_safety_principles: Annotated[bool | None, Body()] = None,
+) -> ScopeGuardV2Response:
+    global scope_guard
+
+    start_time = time.time()
+    result = await scope_guard.validate(
+        conversation,
+        ai_service_description=ai_service_description,
+        skip_evidences=skip_evidences,
+        include_default_safety_principles=include_default_safety_principles,
+        model=model,
+    )
+    end_time = time.time()
+
+    return ScopeGuardV2Response(
+        scope_class=result.scope_class,
+        evidences=result.evidences,
+        reasoning=result.reasoning,
+        suggested_response=result.suggested_response,
+        model=result.model,
+        usage=result.usage,  # type: ignore[invalid-argument-type]
+        time_taken=end_time - start_time,
+    )
+
+
+@app.post(
+    "/orbitals/scope-guard-v2/batch-validate",
+    response_model=list[ScopeGuardV2Response],
+)
+async def batch_validate(
+    conversations: list[ScopeGuardV2Input],
+    ai_service_description: str | AIServiceDescriptionV2 | None = Body(None),
+    ai_service_descriptions: list[str] | list[AIServiceDescriptionV2] | None = Body(
+        None
+    ),
+    skip_evidences: Annotated[bool | None, Body()] = None,
+    model: Annotated[str | None, Body()] = None,
+    include_default_safety_principles: Annotated[bool | None, Body()] = None,
+) -> list[ScopeGuardV2Response]:
+    global scope_guard
+
+    start_time = time.time()
+    results = await scope_guard.batch_validate(
+        conversations,
+        ai_service_description=ai_service_description,
+        ai_service_descriptions=ai_service_descriptions,
+        skip_evidences=skip_evidences,
+        include_default_safety_principles=include_default_safety_principles,
+        model=model,
+    )
+    end_time = time.time()
+
+    return [
+        ScopeGuardV2Response(
+            scope_class=result.scope_class,
+            evidences=result.evidences,
+            reasoning=result.reasoning,
+            suggested_response=result.suggested_response,
+            time_taken=end_time - start_time,
+            model=result.model,
+            usage=result.usage,  # type: ignore[invalid-argument-type]
+        )
+        for result in results
+    ]

--- a/src/orbitals/scope_guard_v2/serving/vllm_logging_config.json
+++ b/src/orbitals/scope_guard_v2/serving/vllm_logging_config.json
@@ -1,0 +1,27 @@
+{
+    "formatters": {
+        "vllm": {
+            "class": "vllm.logging_utils.NewLineFormatter",
+            "datefmt": "%Y-%m-%d %H:%M:%S",
+            "format": "[vLLM] %(levelname)s %(asctime)s %(filename)s:%(lineno)d] %(message)s"
+        }
+    },
+    "handlers": {
+        "vllm": {
+            "class": "logging.StreamHandler",
+            "formatter": "vllm",
+            "level": "INFO",
+            "stream": "ext://sys.stdout"
+        }
+    },
+    "loggers": {
+        "vllm": {
+            "handlers": [
+                "vllm"
+            ],
+            "level": "INFO",
+            "propagate": false
+        }
+    },
+    "version": 1
+}

--- a/src/orbitals/types.py
+++ b/src/orbitals/types.py
@@ -61,3 +61,47 @@ class AIServiceDescription(BaseModel):
         default=None,
         description="The URL of the AI Service website",
     )
+
+
+class PredefinedResponse(BaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    trigger: str = Field(
+        description="When this scenario occurs or topic is mentioned (e.g., 'user asks for support contact', 'mentions billing issues')"
+    )
+    response: str = Field(
+        description="The specific response to provide in this scenario"
+    )
+
+
+class AIServiceDescriptionV2(BaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid")
+
+    identity_role: str = Field(
+        description="Identity, role and objectives of the AI Service. Gives a general idea of what the service is about."
+    )
+    context: str = Field(
+        description="Context in which the AI Service operates. The company, the sector, the users, the location, etc."
+    )
+    knowledge_scope: str | None = Field(
+        default=None, description="Scope of knowledge and expertise of the AI Service"
+    )
+    functionalities: str | list[str] | None = Field(
+        default=None, description="Functionalities provided by the AI Service"
+    )
+    constraints: str | list[str] | None = Field(
+        default=None,
+        description="Things the AI Service should not do, restricted topics, or forbidden actions",
+    )
+    predefined_responses: str | list[str | PredefinedResponse] | None = Field(
+        default=None,
+        description="Specific responses for certain scenarios, topics, or triggers. Can be simple strings describing what to respond with, or structured PredefinedResponse objects for more control",
+    )
+    escalation_criteria: str | list[str] | None = Field(
+        default=None,
+        description="Situations or conditions when queries should be escalated to human oversight",
+    )
+    response_guidelines: str | None = Field(
+        default=None,
+        description="Guidelines for how the AI Service should respond to users (tone, style, format)",
+    )

--- a/tests/test_scope_guard_v2.py
+++ b/tests/test_scope_guard_v2.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+from typer.testing import CliRunner
+
+from orbitals.types import AIServiceDescriptionV2, LLMUsage
+
+
+def _response_payload(**overrides) -> dict[str, Any]:
+    return {
+        "scope_class": overrides.get("scope_class", "Restricted"),
+        "evidences": overrides.get("evidences", ["Do not provide refunds."]),
+        "reasoning": overrides.get("reasoning", "The request matches a constraint."),
+        "suggested_response": overrides.get(
+            "suggested_response", "I cannot help with that request."
+        ),
+        "model": overrides.get("model", "test-scope-guard-v2-model"),
+        "usage": overrides.get(
+            "usage",
+            {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        ),
+    }
+
+
+def test_scope_guard_v2_public_imports():
+    from orbitals.scope_guard_v2 import (
+        AsyncScopeGuardV2,
+        ScopeClass,
+        ScopeGuardV2,
+        ScopeGuardV2Output,
+    )
+
+    assert ScopeGuardV2 is not None
+    assert AsyncScopeGuardV2 is not None
+    assert ScopeClass is not None
+    assert ScopeGuardV2Output is not None
+
+
+def test_scope_guard_v2_package_all_is_exhaustive():
+    import orbitals.scope_guard_v2 as sg
+
+    assert set(sg.__all__) == {
+        "ADDITIONAL_SAFETY_RULES",
+        "AsyncScopeGuardV2",
+        "ScopeClass",
+        "ScopeGuardV2",
+        "ScopeGuardV2Output",
+        "augment_with_default_safety_principles_v2",
+    }
+
+
+def test_scope_guard_v2_scope_classes():
+    from orbitals.scope_guard_v2 import ScopeClass
+
+    assert {m.value for m in ScopeClass} == {
+        "Directly Supported",
+        "Potentially Supported",
+        "Predefined Answer",
+        "Human Oversight",
+        "Out of Scope",
+        "Restricted",
+        "Chit Chat",
+    }
+    assert ScopeClass.RESTRICTED == "Restricted"
+    assert ScopeClass.HUMAN_OVERSIGHT.value == "Human Oversight"
+    assert ScopeClass.HUMAN_REVIEW.value == "Human Oversight"
+
+
+def test_scope_guard_v2_input_accepts_documented_shapes():
+    from orbitals.scope_guard_v2.modeling import (
+        ConversationUserMessage,
+        ScopeGuardV2InputTypeAdapter,
+    )
+    from orbitals.types import ConversationMessage
+
+    assert ScopeGuardV2InputTypeAdapter.validate_python("hello") == "hello"
+
+    single = ScopeGuardV2InputTypeAdapter.validate_python(
+        {"role": "user", "content": "hello"}
+    )
+    assert isinstance(single, ConversationUserMessage)
+
+    multi = ScopeGuardV2InputTypeAdapter.validate_python(
+        [
+            {"role": "user", "content": "q1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "q2"},
+        ]
+    )
+    assert all(isinstance(message, ConversationMessage) for message in multi)
+
+
+def test_scope_guard_v2_rejects_single_assistant_message():
+    from orbitals.scope_guard_v2.modeling import ScopeGuardV2InputTypeAdapter
+
+    with pytest.raises(ValidationError):
+        ScopeGuardV2InputTypeAdapter.validate_python(
+            {"role": "assistant", "content": "hello"}
+        )
+
+
+def test_scope_guard_v2_prompt_requires_last_user_message():
+    from orbitals.scope_guard_v2.prompting import dumps_conversation
+    from orbitals.types import Conversation, ConversationMessage
+
+    with pytest.raises(ValueError, match="last message"):
+        dumps_conversation(
+            Conversation(
+                messages=[
+                    ConversationMessage(role="user", content="q"),
+                    ConversationMessage(role="assistant", content="a"),
+                ]
+            )
+        )
+
+
+def test_scope_guard_v2_prompt_treats_string_as_user_message():
+    from orbitals.scope_guard_v2.prompting import dumps_conversation
+
+    assert "LAST MESSAGE (USER):\nhello" in dumps_conversation("hello")
+
+
+def test_ai_service_description_v2_forbids_extra_fields():
+    with pytest.raises(ValidationError):
+        AIServiceDescriptionV2(
+            identity_role="Role",
+            context="Context",
+            unknown_field="nope",  # type: ignore[call-arg]
+        )
+
+
+def test_scope_guard_v2_model_names_pass_through():
+    from orbitals.scope_guard_v2 import ScopeGuardV2
+
+    assert ScopeGuardV2.maybe_map_model("my-org/v2-model") == "my-org/v2-model"
+    assert ScopeGuardV2.maybe_map_model("scope-guard-q") == "scope-guard-q"
+
+
+def test_scope_guard_v2_default_safety_principles_add_constraints():
+    from orbitals.scope_guard_v2 import (
+        ADDITIONAL_SAFETY_RULES,
+        augment_with_default_safety_principles_v2,
+    )
+
+    desc = AIServiceDescriptionV2(identity_role="Role", context="Context")
+    out = augment_with_default_safety_principles_v2(desc)
+
+    assert isinstance(out, AIServiceDescriptionV2)
+    assert out.constraints == [ADDITIONAL_SAFETY_RULES]
+    assert desc.constraints is None
+
+
+def test_scope_guard_v2_api_backend_augments_safety_constraints(mocked_v2_post):
+    from orbitals.scope_guard_v2 import ADDITIONAL_SAFETY_RULES, ScopeGuardV2
+
+    sg = ScopeGuardV2(
+        backend="api",
+        api_url="http://example.com",
+        include_default_safety_principles=True,
+    )
+    sg.validate(
+        "hello",
+        ai_service_description=AIServiceDescriptionV2(
+            identity_role="Role",
+            context="Context",
+            constraints=["No refunds"],
+        ),
+    )
+
+    constraints = mocked_v2_post.call_args.kwargs["json"]["ai_service_description"][
+        "constraints"
+    ]
+    assert constraints == ["No refunds", ADDITIONAL_SAFETY_RULES]
+
+
+@pytest.fixture
+def mocked_v2_post():
+    with patch("orbitals.scope_guard_v2.guards.api.requests.post") as mocked:
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = _response_payload()
+        mocked.return_value = response
+        yield mocked
+
+
+def test_scope_guard_v2_api_backend_hits_v2_endpoint(mocked_v2_post):
+    from orbitals.scope_guard_v2 import ScopeClass, ScopeGuardV2, ScopeGuardV2Output
+
+    sg = ScopeGuardV2(backend="api", api_url="http://example.com")
+    result = sg.validate("hello", ai_service_description="desc")
+
+    assert mocked_v2_post.call_args.args[0] == (
+        "http://example.com/orbitals/scope-guard-v2/validate"
+    )
+    assert isinstance(result, ScopeGuardV2Output)
+    assert result.scope_class == ScopeClass.RESTRICTED
+    assert result.reasoning == "The request matches a constraint."
+    assert result.suggested_response == "I cannot help with that request."
+
+
+def test_scope_guard_v2_api_backend_serializes_structured_description(
+    mocked_v2_post,
+):
+    from orbitals.scope_guard_v2 import ScopeGuardV2
+
+    sg = ScopeGuardV2(backend="api", api_url="http://example.com", model="v2-model")
+    sg.validate(
+        {"role": "user", "content": "hello"},
+        ai_service_description=AIServiceDescriptionV2(
+            identity_role="Role",
+            context="Context",
+            constraints=["No refunds"],
+        ),
+    )
+
+    body = mocked_v2_post.call_args.kwargs["json"]
+    assert body["model"] == "v2-model"
+    assert body["conversation"] == {"role": "user", "content": "hello"}
+    assert body["ai_service_description"]["constraints"] == ["No refunds"]
+
+
+def test_scope_guard_v2_batch_validate_invariants():
+    from orbitals.scope_guard_v2 import ScopeClass, ScopeGuardV2, ScopeGuardV2Output
+    from orbitals.scope_guard_v2.guards.base import BaseScopeGuardV2
+
+    class _StubScopeGuardV2(ScopeGuardV2):
+        def __new__(cls, *args, **kwargs):
+            return BaseScopeGuardV2.__new__(cls)
+
+        def __init__(self):
+            self.backend = "stub"
+
+        def _batch_validate(self, conversations, **kwargs):
+            return [
+                ScopeGuardV2Output(
+                    evidences=None,
+                    reasoning="ok",
+                    scope_class=ScopeClass.DIRECTLY_SUPPORTED,
+                    suggested_response=None,
+                    model="stub",
+                    usage=None,
+                )
+                for _ in conversations
+            ]
+
+    guard = _StubScopeGuardV2()
+    assert guard.batch_validate([], ai_service_description="desc") == []
+    with pytest.raises(ValueError, match="Either ai_service_description"):
+        guard.batch_validate(["q"])
+    with pytest.raises(ValueError, match="Only one between"):
+        guard.batch_validate(
+            ["q"],
+            ai_service_description="desc",
+            ai_service_descriptions=["desc"],
+        )
+    with pytest.raises(ValueError, match="number of conversations"):
+        guard.batch_validate(["q1", "q2"], ai_service_descriptions=["d1"])
+    assert len(guard.batch_validate(["q1", "q2"], ai_service_description="d")) == 2
+
+
+class _FakeAiohttpResponse:
+    def __init__(self, payload: Any):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    async def json(self):
+        return self._payload
+
+
+class _FakeAiohttpSession:
+    def __init__(self, payload: Any, captured: dict[str, Any]):
+        self._response = _FakeAiohttpResponse(payload)
+        self._captured = captured
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return None
+
+    async def post(self, url, *, json, headers):
+        self._captured["url"] = url
+        self._captured["json"] = json
+        self._captured["headers"] = headers
+        return self._response
+
+
+async def test_scope_guard_v2_async_api_backend(monkeypatch):
+    from orbitals.scope_guard_v2 import AsyncScopeGuardV2, ScopeClass
+
+    captured: dict[str, Any] = {}
+
+    def _session_factory():
+        return _FakeAiohttpSession(_response_payload(), captured)
+
+    monkeypatch.setattr(
+        "orbitals.scope_guard_v2.guards.api.aiohttp.ClientSession",
+        _session_factory,
+    )
+
+    sg = AsyncScopeGuardV2(
+        backend="api",
+        api_url="http://example.com",
+        api_key="secret",
+    )
+    result = await sg.validate("hello", ai_service_description="desc")
+
+    assert captured["url"] == "http://example.com/orbitals/scope-guard-v2/validate"
+    assert captured["headers"]["X-API-Key"] == "secret"
+    assert result.scope_class == ScopeClass.RESTRICTED
+
+
+@pytest.fixture
+def scope_guard_v2_serving_client(monkeypatch):
+    monkeypatch.setenv("SCOPE_GUARD_V2_VLLM_MODEL", "v2-model")
+    monkeypatch.setenv("SCOPE_GUARD_V2_VLLM_SERVING_URL", "http://localhost:8001")
+    monkeypatch.setenv("SCOPE_GUARD_V2_SKIP_EVIDENCES", "0")
+
+    from fastapi.testclient import TestClient
+
+    from orbitals.scope_guard_v2 import ScopeClass, ScopeGuardV2Output
+    from orbitals.scope_guard_v2.serving import main as serving_main
+
+    class _StubAsyncGuard:
+        async def validate(self, conversation, *, ai_service_description, **kwargs):
+            return ScopeGuardV2Output(
+                scope_class=ScopeClass.HUMAN_OVERSIGHT,
+                evidences=["Escalate billing disputes."],
+                reasoning="The request meets an escalation criterion.",
+                suggested_response="A human specialist will review this.",
+                model="stub-model",
+                usage=LLMUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            )
+
+        async def batch_validate(
+            self,
+            conversations,
+            *,
+            ai_service_description=None,
+            ai_service_descriptions=None,
+            **kwargs,
+        ):
+            return [
+                ScopeGuardV2Output(
+                    scope_class=ScopeClass.DIRECTLY_SUPPORTED,
+                    evidences=None,
+                    reasoning="Supported.",
+                    suggested_response=None,
+                    model="stub-model",
+                    usage=LLMUsage(
+                        prompt_tokens=1, completion_tokens=1, total_tokens=2
+                    ),
+                )
+                for _ in conversations
+            ]
+
+    with TestClient(serving_main.app) as client:
+        monkeypatch.setattr(serving_main, "scope_guard", _StubAsyncGuard())
+        yield client
+
+
+def test_scope_guard_v2_serving_validate(scope_guard_v2_serving_client):
+    response = scope_guard_v2_serving_client.post(
+        "/orbitals/scope-guard-v2/validate",
+        json={"conversation": "hello", "ai_service_description": "desc"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["scope_class"] == "Human Oversight"
+    assert body["reasoning"] == "The request meets an escalation criterion."
+    assert body["suggested_response"] == "A human specialist will review this."
+
+
+def test_scope_guard_v2_serving_batch_validate(scope_guard_v2_serving_client):
+    response = scope_guard_v2_serving_client.post(
+        "/orbitals/scope-guard-v2/batch-validate",
+        json={"conversations": ["q1", "q2"], "ai_service_description": "desc"},
+    )
+
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+
+def test_scope_guard_v2_cli_help_and_model_passthrough():
+    from orbitals.cli.main import app
+
+    runner = CliRunner()
+    help_result = runner.invoke(app, ["scope-guard-v2", "serve", "--help"])
+    assert help_result.exit_code == 0
+    assert "--port" in help_result.stdout
+
+    model_result = runner.invoke(
+        app,
+        ["scope-guard-v2", "convert-default-model-name", "scope-guard-q"],
+    )
+    assert model_result.exit_code == 0
+    assert "scope-guard-q" in model_result.stdout

--- a/tests/test_scope_guard_v2.py
+++ b/tests/test_scope_guard_v2.py
@@ -67,7 +67,6 @@ def test_scope_guard_v2_scope_classes():
     }
     assert ScopeClass.RESTRICTED == "Restricted"
     assert ScopeClass.HUMAN_OVERSIGHT.value == "Human Oversight"
-    assert ScopeClass.HUMAN_REVIEW.value == "Human Oversight"
 
 
 def test_scope_guard_v2_input_accepts_documented_shapes():
@@ -131,13 +130,6 @@ def test_ai_service_description_v2_forbids_extra_fields():
             context="Context",
             unknown_field="nope",  # type: ignore[call-arg]
         )
-
-
-def test_scope_guard_v2_model_names_pass_through():
-    from orbitals.scope_guard_v2 import ScopeGuardV2
-
-    assert ScopeGuardV2.maybe_map_model("my-org/v2-model") == "my-org/v2-model"
-    assert ScopeGuardV2.maybe_map_model("scope-guard-q") == "scope-guard-q"
 
 
 def test_scope_guard_v2_default_safety_principles_add_constraints():


### PR DESCRIPTION
## What & Why
Introduces **ScopeGuard V2**, the next generation of ScopeGuard. Given an AI service specification and a conversation, it classifies the final user message into one of seven scope classes — Directly Supported, Potentially Supported, Predefined Answer, Human Oversight, Out of Scope, Restricted, and Chit Chat — and returns supporting evidences, reasoning, and a ready-to-use suggested response. This expands on V1's binary in/out-of-scope decision to give services finer-grained, actionable routing (e.g. escalate to a human, return a predefined answer).

## Changes
- New `orbitals.scope_guard_v2` package exposing `ScopeGuardV2` / `AsyncScopeGuardV2`, the `ScopeClass` enum, and `api`, `hf`, and `vllm` guard backends over a shared `base` guard.
- Structured `AIServiceDescriptionV2` (plus `PredefinedResponse`) in `orbitals.types`, driving the new classes: `predefined_responses` → Predefined Answer, `escalation_criteria` → Human Oversight, `constraints` → Restricted. Plain-string descriptions remain supported.
- Serving stack: `orbitals scope-guard-v2 serve` CLI, vLLM serving entrypoint, and logging config (gated on the still-private model weights).
- `validate` / `batch_validate` accept the same input formats as V1 (string, OpenAI message dict, conversation list), with `skip_evidences` and `include_default_safety_principles` toggles available per-guard or per-call.
- HF pipeline (`src/hf_pipeline/scope_guard_v2.py`), prompting, modeling, and default safety principles modules.
- Registered V2 in the top-level CLI and `README.md`; added a dedicated `README.scope-guard-v2.md`.
- Dropped the `maybe_map_model` alias scaffolding and a duplicate `HUMAN_REVIEW` enum alias while V2 models remain private, and aligned prompt wording with the `LAST MESSAGE` tag.

## Notes for Reviewer
The ScopeGuard V2 models are currently **private and API-only** through Principled Intelligence's hosted service; the `hf`/`vllm`/serving backends ship but require model weights that aren't yet released, so self-hosting is not yet functional. An open-weight release is planned.

## Testing
Unit tests added in `tests/test_scope_guard_v2.py` (~400 lines).